### PR TITLE
feat: highlight shortest unique prefix for change IDs

### DIFF
--- a/lua/neojj/buffers/status/ui.lua
+++ b/lua/neojj/buffers/status/ui.lua
@@ -86,6 +86,11 @@ local JJHead = Component.new(function(props)
   local short_change = change_id:sub(1, 8)
   local short_commit = commit_id:sub(1, 8)
 
+  -- Split change_id into shortest unique prefix and rest
+  local prefix_len = props.shortest_prefix and #props.shortest_prefix or #short_change
+  local change_prefix = short_change:sub(1, prefix_len)
+  local change_rest = short_change:sub(prefix_len + 1)
+
   local bookmark_parts = {}
   if props.bookmarks and #props.bookmarks > 0 then
     for _, bm in ipairs(props.bookmarks) do
@@ -106,7 +111,8 @@ local JJHead = Component.new(function(props)
   local header_parts = {
     text.highlight("NeojjStatusHEAD")(util.pad_right(props.name .. ": ", props.HEAD_padding or 10)),
     text.highlight("NeojjBranch")(props.symbol .. " "),
-    text.highlight("NeojjChangeId")(short_change),
+    text.highlight("NeojjChangeIdPrefix")(change_prefix),
+    text.highlight("NeojjChangeIdRest")(change_rest),
     text(" "),
     text.highlight("NeojjObjectId")(short_commit),
   }
@@ -251,6 +257,11 @@ local SectionItemChange = Component.new(function(item)
   local change_id = (item.change_id or ""):sub(1, 8)
   local commit_id = (item.commit_id or ""):sub(1, 8)
 
+  -- Split change_id into shortest unique prefix and rest
+  local prefix_len = item.shortest_prefix and #item.shortest_prefix or #change_id
+  local change_prefix = change_id:sub(1, prefix_len)
+  local change_rest = change_id:sub(prefix_len + 1)
+
   local bookmark_parts = {}
   if item.bookmarks and #item.bookmarks > 0 then
     for _, bm in ipairs(item.bookmarks) do
@@ -283,7 +294,8 @@ local SectionItemChange = Component.new(function(item)
   local status_suffix = #status_parts > 0 and " (" .. table.concat(status_parts, ", ") .. ")" or ""
 
   local parts = {
-    text.highlight("NeojjChangeId")(change_id),
+    text.highlight("NeojjChangeIdPrefix")(change_prefix),
+    text.highlight("NeojjChangeIdRest")(change_rest),
     text(" "),
     text.highlight("NeojjObjectId")(commit_id),
   }
@@ -378,6 +390,7 @@ function M.Status(state, config)
             bookmarks = state.head.bookmarks,
             empty = state.head.empty,
             conflict = state.head.conflict,
+            shortest_prefix = state.head.shortest_prefix,
             HEAD_padding = HEAD_padding,
           },
           EmptyLine(),
@@ -390,6 +403,7 @@ function M.Status(state, config)
             bookmarks = state.parent.bookmarks,
             empty = false,
             conflict = false,
+            shortest_prefix = state.parent.shortest_prefix,
             HEAD_padding = HEAD_padding,
           },
         }, { foldable = true, folded = config.status and config.status.HEAD_folded }),

--- a/lua/neojj/config.lua
+++ b/lua/neojj/config.lua
@@ -1038,12 +1038,18 @@ end
 
 ---@param name string
 ---@return boolean
+-- Map integration config keys to their actual Lua module names
+local integration_modules = {
+  mini_pick = "mini.pick",
+}
+
 function M.check_integration(name)
   local logger = require("neojj.logger")
   local enabled = M.values.integrations[name]
 
   if enabled == nil or enabled == "auto" then
-    local success, _ = pcall(require, name:gsub("_", "-"))
+    local mod_name = integration_modules[name] or name:gsub("_", "-")
+    local success, _ = pcall(require, mod_name)
     logger.info(("[CONFIG] Found auto integration '%s = %s'"):format(name, success))
     return success
   end

--- a/lua/neojj/lib/finder.lua
+++ b/lua/neojj/lib/finder.lua
@@ -153,13 +153,30 @@ local function fzf_actions(on_select, allow_multi, refocus_status)
   }
 end
 
+--- Extract plain text strings from entries (handles both string and table entries)
+---@param entries any[]
+---@return string[]
+local function entries_to_strings(entries)
+  local result = {}
+  for _, entry in ipairs(entries) do
+    if type(entry) == "table" then
+      table.insert(result, entry.text)
+    else
+      table.insert(result, entry)
+    end
+  end
+  return result
+end
+
 ---Convert entries to snack picker items
 ---@param entries any[]
 ---@return any[]
 local function entries_to_snack_items(entries)
   local items = {}
   for idx, entry in ipairs(entries) do
-    table.insert(items, { idx = idx, score = 0, text = entry })
+    local text = type(entry) == "table" and entry.text or entry
+    local prefix_len = type(entry) == "table" and entry.prefix_len or nil
+    table.insert(items, { idx = idx, score = 0, text = text, prefix_len = prefix_len })
   end
   return items
 end
@@ -328,14 +345,14 @@ function Finder:find(on_select)
 
     pickers
       .new(self.opts, {
-        finder = finders.new_table { results = self.entries },
+        finder = finders.new_table { results = entries_to_strings(self.entries) },
         sorter = config.values.telescope_sorter() or default_sorter,
         attach_mappings = telescope_mappings(on_select, self.opts.allow_multi, self.opts.refocus_status),
       })
       :find()
   elseif config.check_integration("fzf_lua") then
     local fzf_lua = require("fzf-lua")
-    fzf_lua.fzf_exec(self.entries, {
+    fzf_lua.fzf_exec(entries_to_strings(self.entries), {
       prompt = string.format("%s> ", self.opts.prompt_prefix),
       fzf_opts = fzf_opts(self.opts),
       winopts = {
@@ -347,15 +364,96 @@ function Finder:find(on_select)
     })
   elseif config.check_integration("mini_pick") then
     local mini_pick = require("mini.pick")
-    mini_pick.start { source = { items = self.entries, choose = on_select } }
+
+    -- Build a lookup from display text -> prefix_len for bold highlighting
+    local prefix_lookup = {}
+    for _, entry in ipairs(self.entries) do
+      if type(entry) == "table" and entry.prefix_len then
+        prefix_lookup[entry.text] = entry.prefix_len
+      end
+    end
+
+    local string_items = entries_to_strings(self.entries)
+    local has_prefixes = next(prefix_lookup) ~= nil
+
+    local show = nil
+    if has_prefixes then
+      local ns = vim.api.nvim_create_namespace("neojj_picker_prefix")
+      show = function(buf_id, items_to_show, query, opts)
+        mini_pick.default_show(buf_id, items_to_show, query, opts)
+        vim.api.nvim_buf_clear_namespace(buf_id, ns, 0, -1)
+        for i, item in ipairs(items_to_show) do
+          local item_text = type(item) == "string" and item or tostring(item)
+          local plen = prefix_lookup[item_text]
+          if plen and plen > 0 then
+            -- Bold prefix
+            vim.api.nvim_buf_set_extmark(buf_id, ns, i - 1, 0, {
+              end_col = plen,
+              hl_group = "NeojjChangeIdPrefix",
+              hl_mode = "combine",
+              priority = 210,
+            })
+            -- Dim rest of change_id (up to first space)
+            local rest_end = item_text:find(" ") or (#item_text + 1)
+            if rest_end > plen + 1 then
+              vim.api.nvim_buf_set_extmark(buf_id, ns, i - 1, plen, {
+                end_col = rest_end - 1,
+                hl_group = "NeojjChangeIdRest",
+                hl_mode = "combine",
+                priority = 210,
+              })
+            end
+          end
+        end
+      end
+    end
+
+    mini_pick.start {
+      source = {
+        items = string_items,
+        choose = on_select,
+        show = show or nil,
+      },
+    }
   elseif config.check_integration("snacks") then
     local snacks_picker = require("snacks.picker")
     local confirm, on_close = snacks_confirm(on_select, self.opts.allow_multi, self.opts.refocus_status)
+    local snack_items = entries_to_snack_items(self.entries)
+
+    -- Check if any items have prefix_len for change ID highlighting
+    local has_prefixes = false
+    for _, item in ipairs(snack_items) do
+      if item.prefix_len then
+        has_prefixes = true
+        break
+      end
+    end
+
+    local format_fn = "text"
+    if has_prefixes then
+      format_fn = function(item)
+        local ret = {}
+        local item_text = item.text or ""
+        local plen = item.prefix_len
+        if plen and plen > 0 and plen < #item_text then
+          local space_pos = item_text:find(" ") or (#item_text + 1)
+          ret[#ret + 1] = { item_text:sub(1, plen), "NeojjChangeIdPrefix" }
+          if space_pos > plen + 1 then
+            ret[#ret + 1] = { item_text:sub(plen + 1, space_pos - 1), "NeojjChangeIdRest" }
+          end
+          ret[#ret + 1] = { item_text:sub(space_pos) }
+        else
+          ret[#ret + 1] = { item_text }
+        end
+        return ret
+      end
+    end
+
     snacks_picker.pick(nil, {
       title = "Neojj",
       prompt = string.format("%s > ", self.opts.prompt_prefix),
-      items = entries_to_snack_items(self.entries),
-      format = "text",
+      items = snack_items,
+      format = format_fn,
       layout = {
         preset = self.opts.theme,
         preview = self.opts.previewer,
@@ -366,7 +464,7 @@ function Finder:find(on_select)
       on_close = on_close,
     })
   else
-    vim.ui.select(self.entries, {
+    vim.ui.select(entries_to_strings(self.entries), {
       prompt = string.format("%s: ", self.opts.prompt_prefix),
       format_item = function(entry)
         return entry

--- a/lua/neojj/lib/hl.lua
+++ b/lua/neojj/lib/hl.lua
@@ -228,6 +228,8 @@ function M.setup(config)
     NeojjRemote                   = { fg = palette.green, bold = palette.bold, ctermfg = 2 },
     NeojjObjectId                 = { fg = palette.bg_cyan, ctermfg = 7 },
     NeojjChangeId                 = { fg = palette.bg_purple, ctermfg = 6 },
+    NeojjChangeIdPrefix           = { fg = palette.purple, bold = palette.bold, ctermfg = 5 },
+    NeojjChangeIdRest             = { fg = palette.bg_purple, ctermfg = 6 },
     NeojjConflict                 = { fg = "#f0c674", bold = true, ctermfg = 3 },
     NeojjImmutable                = { fg = palette.grey, italic = palette.italic, ctermfg = 7 },
     NeojjWorkingCopy              = { fg = palette.green, bold = palette.bold, ctermfg = 2 },

--- a/lua/neojj/lib/jj/log.lua
+++ b/lua/neojj/lib/jj/log.lua
@@ -132,7 +132,7 @@ end
 ---@param limit? number Max entries
 ---@return NeojjChangeLogEntry[]
 -- Template that appends immutable/empty/conflict/bookmarks as tab-separated fields after json
-local LIST_TEMPLATE = 'json(self) ++ if(immutable, "\\t1", "\\t0") ++ if(empty, "\\t1", "\\t0") ++ if(conflict, "\\t1", "\\t0") ++ "\\t" ++ local_bookmarks.map(|b| b.name()).join(",") ++ "\\t" ++ remote_bookmarks.filter(|b| b.remote() != "git").map(|b| b.name() ++ "@" ++ b.remote()).join(",") ++ "\\n"'
+local LIST_TEMPLATE = 'json(self) ++ if(immutable, "\\t1", "\\t0") ++ if(empty, "\\t1", "\\t0") ++ if(conflict, "\\t1", "\\t0") ++ "\\t" ++ local_bookmarks.map(|b| b.name()).join(",") ++ "\\t" ++ remote_bookmarks.filter(|b| b.remote() != "git").map(|b| b.name() ++ "@" ++ b.remote()).join(",") ++ "\\t" ++ change_id.shortest(8).prefix() ++ "\\n"'
 
 --- Parse lines produced by LIST_TEMPLATE into entries
 ---@param lines string[]
@@ -155,6 +155,9 @@ local function parse_enriched_lines(lines)
           end
           if parts[5] and parts[5] ~= "" then
             entry.remote_bookmarks = vim.split(parts[5], ",")
+          end
+          if parts[6] and parts[6] ~= "" then
+            entry.shortest_prefix = parts[6]
           end
           table.insert(entries, entry)
         end
@@ -243,21 +246,37 @@ function meta.update(state)
   local entries = (code == 0 and lines) and parse_enriched_lines(lines) or {}
   state.recent.items = entries
 
-  -- Enrich head description from log if status didn't provide it
-  if #entries > 0 and state.head.change_id ~= "" then
+  -- Enrich head and parent from log data (description, shortest_prefix)
+  if #entries > 0 then
     for _, entry in ipairs(entries) do
-      if entry.change_id == state.head.change_id
+      -- Match head
+      if state.head.change_id ~= "" and (
+        entry.change_id == state.head.change_id
         or state.head.change_id:find(entry.change_id, 1, true) == 1
-        or entry.change_id:find(state.head.change_id, 1, true) == 1 then
+        or entry.change_id:find(state.head.change_id, 1, true) == 1
+      ) then
         if entry.description ~= "" and (state.head.description == "" or state.head.description:match("^%(")) then
           state.head.description = entry.description
         end
-        break
+        if entry.shortest_prefix then
+          state.head.shortest_prefix = entry.shortest_prefix
+        end
+      end
+      -- Match parent
+      if state.parent.change_id ~= "" and (
+        entry.change_id == state.parent.change_id
+        or state.parent.change_id:find(entry.change_id, 1, true) == 1
+        or entry.change_id:find(state.parent.change_id, 1, true) == 1
+      ) then
+        if entry.shortest_prefix then
+          state.parent.shortest_prefix = entry.shortest_prefix
+        end
       end
     end
   end
 end
 
 M.meta = meta
+M.parse_enriched_lines = parse_enriched_lines
 
 return M

--- a/lua/neojj/lib/picker_cache.lua
+++ b/lua/neojj/lib/picker_cache.lua
@@ -19,6 +19,7 @@ function M.get_all_revisions()
   local entries = {}
   for _, item in ipairs(items) do
     local short_id = (item.change_id or ""):sub(1, 8)
+    local prefix_len = item.shortest_prefix and #item.shortest_prefix or #short_id
     local label = short_id
     if item.description and item.description ~= "" then
       local first_line = vim.split(item.description, "\n")[1]
@@ -27,7 +28,7 @@ function M.get_all_revisions()
     if item.bookmarks and #item.bookmarks > 0 then
       label = label .. " [" .. table.concat(item.bookmarks, ", ") .. "]"
     end
-    table.insert(entries, label)
+    table.insert(entries, { text = label, prefix_len = prefix_len })
   end
 
   _cache.revisions = entries
@@ -66,12 +67,22 @@ function M.invalidate()
   _cache.bookmarks = nil
 end
 
+--- Extract text from a revision entry (handles both string and table entries)
+---@param entry string|table
+---@return string
+local function entry_text(entry)
+  if type(entry) == "table" then
+    return entry.text
+  end
+  return entry
+end
+
 --- Remove a specific revision from the cache by its short change_id prefix
 function M.remove_revision(change_id)
   _cache.bookmarks = nil -- bookmark on abandoned commit may be affected
   if not _cache.revisions then return end
   for i, entry in ipairs(_cache.revisions) do
-    if entry:sub(1, #change_id) == change_id then
+    if entry_text(entry):sub(1, #change_id) == change_id then
       table.remove(_cache.revisions, i)
       return
     end
@@ -82,9 +93,10 @@ end
 function M.update_revision_description(change_id, new_desc)
   if not _cache.revisions then return end
   for i, entry in ipairs(_cache.revisions) do
-    if entry:sub(1, #change_id) == change_id then
+    if entry_text(entry):sub(1, #change_id) == change_id then
       local first_line = vim.split(new_desc, "\n")[1]
-      _cache.revisions[i] = change_id .. " " .. first_line
+      local prefix_len = type(entry) == "table" and entry.prefix_len or #change_id
+      _cache.revisions[i] = { text = change_id .. " " .. first_line, prefix_len = prefix_len }
       return
     end
   end
@@ -131,13 +143,15 @@ end
 
 --- Extract the first whitespace-delimited token from a picker selection.
 --- Works for both revision entries ("change_id description") and bookmark entries ("name change_id desc").
----@param selection string?
+--- Handles both plain string selections and structured table entries.
+---@param selection string|table|nil
 ---@return string?
 function M.parse_selection(selection)
   if not selection then
     return nil
   end
-  return selection:match("^(%S+)")
+  local text = type(selection) == "table" and selection.text or selection
+  return text:match("^(%S+)")
 end
 
 --- Extract a human-readable error message from a command result's stderr.

--- a/tests/specs/neojj/config_spec.lua
+++ b/tests/specs/neojj/config_spec.lua
@@ -624,4 +624,24 @@ describe("NeoJJ config", function()
       end)
     end)
   end)
+
+  describe("check_integration", function()
+    it("should resolve mini_pick to mini.pick module", function()
+      -- When mini.pick is available, check_integration("mini_pick") should find it
+      -- via the integration_modules mapping instead of trying require("mini-pick")
+      config.values.integrations = {}
+      local has_mini_pick = pcall(require, "mini.pick")
+      assert.are.equal(has_mini_pick, config.check_integration("mini_pick"))
+    end)
+
+    it("should respect explicit integration overrides", function()
+      config.values.integrations = { mini_pick = false }
+      assert.is_false(config.check_integration("mini_pick"))
+    end)
+
+    it("should respect explicit true override", function()
+      config.values.integrations = { mini_pick = true }
+      assert.is_true(config.check_integration("mini_pick"))
+    end)
+  end)
 end)

--- a/tests/specs/neojj/lib/jj/log_spec.lua
+++ b/tests/specs/neojj/lib/jj/log_spec.lua
@@ -153,4 +153,56 @@ describe("jj log parser", function()
       assert.are.equal("subject line", entry.description)
     end)
   end)
+
+  describe("parse_enriched_lines", function()
+    local function make_line(json_obj, flags)
+      return vim.json.encode(json_obj) .. "\t" .. flags
+    end
+
+    local sample_json = {
+      change_id = "muvqvxnnyrwstlmspzqvvqzmqstxmzwq",
+      commit_id = "7809cff3fa826599726c858a8c387ddc46fb7a72",
+      description = "add feature\n",
+    }
+
+    it("extracts shortest_prefix from the 6th tab field", function()
+      local line = make_line(sample_json, "0\t0\t0\t\t\tmuvq")
+      local entries = log.parse_enriched_lines({ line })
+      assert.are.equal(1, #entries)
+      assert.are.equal("muvq", entries[1].shortest_prefix)
+    end)
+
+    it("handles single-character shortest_prefix", function()
+      local line = make_line(sample_json, "0\t0\t0\t\t\tm")
+      local entries = log.parse_enriched_lines({ line })
+      assert.are.equal("m", entries[1].shortest_prefix)
+    end)
+
+    it("sets shortest_prefix to nil when 6th field is empty", function()
+      local line = make_line(sample_json, "0\t0\t0\t\t")
+      local entries = log.parse_enriched_lines({ line })
+      assert.is_nil(entries[1].shortest_prefix)
+    end)
+
+    it("parses bookmarks and shortest_prefix together", function()
+      local line = make_line(sample_json, "0\t0\t0\tmain,dev\torigin@main\tmuvq")
+      local entries = log.parse_enriched_lines({ line })
+      assert.are.same({ "main", "dev" }, entries[1].bookmarks)
+      assert.are.same({ "origin@main" }, entries[1].remote_bookmarks)
+      assert.are.equal("muvq", entries[1].shortest_prefix)
+    end)
+
+    it("parses immutable, empty, and conflict flags", function()
+      local line = make_line(sample_json, "1\t1\t1\t\t\tmuvq")
+      local entries = log.parse_enriched_lines({ line })
+      assert.is_true(entries[1].immutable)
+      assert.is_true(entries[1].empty)
+      assert.is_true(entries[1].conflict)
+    end)
+
+    it("skips empty lines", function()
+      local entries = log.parse_enriched_lines({ "", "" })
+      assert.are.equal(0, #entries)
+    end)
+  end)
 end)

--- a/tests/specs/neojj/lib/picker_cache_spec.lua
+++ b/tests/specs/neojj/lib/picker_cache_spec.lua
@@ -1,0 +1,27 @@
+local picker_cache = require("neojj.lib.picker_cache")
+
+describe("picker_cache", function()
+  describe("parse_selection", function()
+    it("extracts first token from a plain string", function()
+      assert.are.equal("muvqvxnn", picker_cache.parse_selection("muvqvxnn add feature"))
+    end)
+
+    it("extracts first token from a table entry", function()
+      local entry = { text = "muvqvxnn add feature", prefix_len = 4 }
+      assert.are.equal("muvqvxnn", picker_cache.parse_selection(entry))
+    end)
+
+    it("returns nil for nil input", function()
+      assert.is_nil(picker_cache.parse_selection(nil))
+    end)
+
+    it("handles table entry with bookmarks", function()
+      local entry = { text = "muvqvxnn add feature [main]", prefix_len = 1 }
+      assert.are.equal("muvqvxnn", picker_cache.parse_selection(entry))
+    end)
+
+    it("handles string with only change_id", function()
+      assert.are.equal("muvqvxnn", picker_cache.parse_selection("muvqvxnn"))
+    end)
+  end)
+end)


### PR DESCRIPTION
Adds a visual distinction for the shortest unique prefix in a change ID, matching the highlighting behavior from `jj log`. 

Closes #2

## Changes

- Add `NeojjChangeIdPrefix` and `NeojjChangeIdRest` highlight groups in `lua/neojj/lib/hl.lua`
- Update `LIST_TEMPLATE` to include `change_id.shortest(8).prefix()` in the log output
- Parse `shortest_prefix` from enriched log lines and propagate to head/parent state
- Apply prefix highlighting in status buffer for both HEAD and parent entries
- Add unit tests for `parse_enriched_lines` covering prefix extraction scenarios

## Testing

- Added tests in `tests/specs/neojj/lib/jj/log_spec.lua` for prefix parsing
- Manual testing: status buffer now shows the shortest unique prefix in a distinct highlight

### AI Disclosure

I used Claude Code to help get a grasp on the code base and find where to implement the changes. I figured I would include this just in case you had any opinions around that.