### PR TITLE
fix: resolve workspace root and clarify error notification when custom cwd is provided

### DIFF
--- a/lua/neojj.lua
+++ b/lua/neojj.lua
@@ -140,7 +140,9 @@ function M.open(opts)
   opts = construct_opts(opts)
 
   if not opts._workspace_root then
-    M.notification.error("The current working directory is not a jj workspace")
+    local failed_path = vim.fn.expand(opts.cwd or ".")
+    M.notification.error(("The directory `%s` is not a jj workspace"):format(failed_path))
+
     return
   end
 

--- a/lua/neojj.lua
+++ b/lua/neojj.lua
@@ -82,12 +82,10 @@ local function construct_opts(opts)
     opts.cwd = vim.fn.expand(opts.cwd)
   end
 
-  if not opts.cwd then
-    local jj_cli = require("neojj.lib.jj.cli")
-    local root = jj_cli.find_workspace_root(".")
-    opts.cwd = root or vim.uv.cwd()
-    opts._workspace_root = root
-  end
+  opts.cwd = opts.cwd or vim.fn.getcwd()
+
+  local jj_cli = require("neojj.lib.jj.cli")
+  opts._workspace_root = jj_cli.find_workspace_root(opts.cwd)
 
   return opts
 end


### PR DESCRIPTION
This fixes an issue where passing a custom `opts.cwd` skipped setting `opts._workspace_root`, causing `open()` to crash with a false-positive "not a jj workspace" error.

**Changes:**
* Refactored `construct_opts` so it always resolves and sets `opts._workspace_root`, regardless of the input.
* Updated the validation error to show the fully expanded path instead of a generic message. This clears up any confusion if Neovim's internal CWD doesn't match what the user expects.

**Testing:**
Verified via user commands (`Neojj cwd=<path>`) and direct Lua API calls (`require('neojj').open({ cwd = <path> })`). Tested and working against:
* A valid `jj` workspace root.
* A nested subdirectory inside a workspace.
* An invalid, non-workspace directory (correctly triggers the new error format).