### PR TITLE
feat(push): surface jj warnings on successful push

### DIFF
--- a/lua/neojj/popups/push/actions.lua
+++ b/lua/neojj/popups/push/actions.lua
@@ -19,6 +19,38 @@ local function push_error_msg(result)
   return stderr
 end
 
+--- Extract jj `Warning:` blocks (and their `Hint:`/indented continuations) from stderr.
+--- Returns the joined block text when at least one `Warning:` line is present, otherwise nil.
+--- jj emits all warnings via a centralized `Warning: ` prefix helper, so prefix matching is reliable.
+---@param stderr string[]?
+---@return string?
+local function extract_warnings(stderr)
+  if not stderr or #stderr == 0 then
+    return nil
+  end
+  local lines = {}
+  local in_block = false
+  local saw_warning = false
+  for _, line in ipairs(stderr) do
+    if line:match("^Warning:") then
+      table.insert(lines, line)
+      in_block = true
+      saw_warning = true
+    elseif line:match("^Hint:") then
+      table.insert(lines, line)
+      in_block = true
+    elseif in_block and line:match("^%s") then
+      table.insert(lines, line)
+    else
+      in_block = false
+    end
+  end
+  if not saw_warning then
+    return nil
+  end
+  return table.concat(lines, "\n")
+end
+
 ---@param lines string[]?
 ---@return string[]
 local function parse_remotes(lines)
@@ -85,7 +117,15 @@ local function run_push(popup, base_builder, subject)
 
   local result = builder.call()
   if result and result.code == 0 then
-    notification.info("Pushed" .. subject_str .. remote_str, { dismiss = true })
+    local warnings = extract_warnings(result.stderr)
+    if warnings then
+      notification.warn(
+        "Pushed" .. subject_str .. remote_str .. " with warnings:\n" .. warnings,
+        { dismiss = true }
+      )
+    else
+      notification.info("Pushed" .. subject_str .. remote_str, { dismiss = true })
+    end
   else
     notification.warn("Push failed: " .. push_error_msg(result), { dismiss = true })
   end

--- a/tests/specs/neojj/popups/push/actions_spec.lua
+++ b/tests/specs/neojj/popups/push/actions_spec.lua
@@ -26,8 +26,9 @@ local function with_actions_module(stubs, fn)
 end
 
 ---@param kind string
+---@param result table?
 ---@return table
-local function new_builder(kind)
+local function new_builder(kind, result)
   local builder = {
     kind = kind,
     called = false,
@@ -48,7 +49,7 @@ local function new_builder(kind)
 
   builder.call = function()
     builder.called = true
-    return { code = 0, stderr = {} }
+    return result or { code = 0, stderr = {} }
   end
 
   return builder
@@ -498,6 +499,168 @@ describe("push popup actions remote mode", function()
     assert.are.same({ "--dry-run" }, push_builder.args_values)
     assert.is_nil(push_builder.remote_value)
     assert.is_true(has_message(info_messages, "Pushed"))
+  end)
+
+  it("surfaces jj warnings when push exits 0", function()
+    local push_builder = new_builder("push", {
+      code = 0,
+      stderr = {
+        "Warning: Non-tracking remote bookmark foo@origin exists",
+        "Hint: Run `jj bookmark track foo --remote=origin` to import the remote bookmark.",
+        "Nothing changed.",
+      },
+    })
+    local info_messages = {}
+    local warn_messages = {}
+
+    with_actions_module({
+      ["neojj.lib.jj"] = {
+        cli = {
+          git_push = push_builder,
+          git_remote_list = {
+            call = function()
+              return { code = 0, stdout = { "origin git@example/origin" } }
+            end,
+          },
+        },
+      },
+      ["neojj.lib.notification"] = {
+        info = function(msg)
+          table.insert(info_messages, msg)
+        end,
+        warn = function(msg)
+          table.insert(warn_messages, msg)
+        end,
+      },
+      ["neojj.buffers.fuzzy_finder"] = {
+        new = function()
+          error("unexpected remote picker invocation")
+        end,
+      },
+      ["neojj.lib.picker_cache"] = {
+        get_local_bookmark_names = function()
+          return {}
+        end,
+        get_all_revisions = function()
+          return {}
+        end,
+        parse_selection = function(selection)
+          return selection
+        end,
+        error_msg = function()
+          return "err"
+        end,
+      },
+    }, function(actions)
+      local popup = {
+        get_arguments = function()
+          return {}
+        end,
+        get_internal_arguments = function()
+          return {}
+        end,
+      }
+      actions.push(popup)
+    end)
+
+    assert.is_true(push_builder.called)
+    assert.is_false(has_message(info_messages, "Pushed"))
+    assert.is_true(has_message(warn_messages, "with warnings"))
+    assert.is_true(has_message(warn_messages, "Non-tracking remote bookmark foo@origin"))
+    assert.is_true(has_message(warn_messages, "jj bookmark track foo"))
+  end)
+
+  it("captures indented continuation lines after a warning", function()
+    local push_builder = new_builder("push", {
+      code = 0,
+      stderr = {
+        "Warning: Failed to export some bookmarks:",
+        "  fred@git: Ref cannot point to the root commit in Git",
+        "Nothing changed.",
+      },
+    })
+    local warn_messages = {}
+
+    with_actions_module({
+      ["neojj.lib.jj"] = {
+        cli = {
+          git_push = push_builder,
+          git_remote_list = { call = function() return { code = 0, stdout = {} } end },
+        },
+      },
+      ["neojj.lib.notification"] = {
+        info = function() end,
+        warn = function(msg)
+          table.insert(warn_messages, msg)
+        end,
+      },
+      ["neojj.buffers.fuzzy_finder"] = {
+        new = function()
+          error("unexpected remote picker invocation")
+        end,
+      },
+      ["neojj.lib.picker_cache"] = {
+        get_local_bookmark_names = function() return {} end,
+        get_all_revisions = function() return {} end,
+        parse_selection = function(s) return s end,
+        error_msg = function() return "err" end,
+      },
+    }, function(actions)
+      local popup = {
+        get_arguments = function() return {} end,
+        get_internal_arguments = function() return {} end,
+      }
+      actions.push(popup)
+    end)
+
+    assert.is_true(has_message(warn_messages, "Failed to export some bookmarks"))
+    assert.is_true(has_message(warn_messages, "fred@git: Ref cannot point to the root commit"))
+  end)
+
+  it("does not flag success notifications when stderr has only status lines", function()
+    local push_builder = new_builder("push", {
+      code = 0,
+      stderr = { "Changes to push to origin:", "  Add bookmark main" },
+    })
+    local info_messages = {}
+    local warn_messages = {}
+
+    with_actions_module({
+      ["neojj.lib.jj"] = {
+        cli = {
+          git_push = push_builder,
+          git_remote_list = { call = function() return { code = 0, stdout = {} } end },
+        },
+      },
+      ["neojj.lib.notification"] = {
+        info = function(msg)
+          table.insert(info_messages, msg)
+        end,
+        warn = function(msg)
+          table.insert(warn_messages, msg)
+        end,
+      },
+      ["neojj.buffers.fuzzy_finder"] = {
+        new = function()
+          error("unexpected remote picker invocation")
+        end,
+      },
+      ["neojj.lib.picker_cache"] = {
+        get_local_bookmark_names = function() return {} end,
+        get_all_revisions = function() return {} end,
+        parse_selection = function(s) return s end,
+        error_msg = function() return "err" end,
+      },
+    }, function(actions)
+      local popup = {
+        get_arguments = function() return {} end,
+        get_internal_arguments = function() return {} end,
+      }
+      actions.push(popup)
+    end)
+
+    assert.is_true(has_message(info_messages, "Pushed"))
+    assert.is_false(has_message(warn_messages, "with warnings"))
   end)
 
   it("applies selected remote for plain push", function()

--- a/tests/specs/neojj/popups/push/actions_spec.lua
+++ b/tests/specs/neojj/popups/push/actions_spec.lua
@@ -585,7 +585,11 @@ describe("push popup actions remote mode", function()
       ["neojj.lib.jj"] = {
         cli = {
           git_push = push_builder,
-          git_remote_list = { call = function() return { code = 0, stdout = {} } end },
+          git_remote_list = {
+            call = function()
+              return { code = 0, stdout = {} }
+            end,
+          },
         },
       },
       ["neojj.lib.notification"] = {
@@ -600,15 +604,27 @@ describe("push popup actions remote mode", function()
         end,
       },
       ["neojj.lib.picker_cache"] = {
-        get_local_bookmark_names = function() return {} end,
-        get_all_revisions = function() return {} end,
-        parse_selection = function(s) return s end,
-        error_msg = function() return "err" end,
+        get_local_bookmark_names = function()
+          return {}
+        end,
+        get_all_revisions = function()
+          return {}
+        end,
+        parse_selection = function(s)
+          return s
+        end,
+        error_msg = function()
+          return "err"
+        end,
       },
     }, function(actions)
       local popup = {
-        get_arguments = function() return {} end,
-        get_internal_arguments = function() return {} end,
+        get_arguments = function()
+          return {}
+        end,
+        get_internal_arguments = function()
+          return {}
+        end,
       }
       actions.push(popup)
     end)
@@ -629,7 +645,11 @@ describe("push popup actions remote mode", function()
       ["neojj.lib.jj"] = {
         cli = {
           git_push = push_builder,
-          git_remote_list = { call = function() return { code = 0, stdout = {} } end },
+          git_remote_list = {
+            call = function()
+              return { code = 0, stdout = {} }
+            end,
+          },
         },
       },
       ["neojj.lib.notification"] = {
@@ -646,15 +666,27 @@ describe("push popup actions remote mode", function()
         end,
       },
       ["neojj.lib.picker_cache"] = {
-        get_local_bookmark_names = function() return {} end,
-        get_all_revisions = function() return {} end,
-        parse_selection = function(s) return s end,
-        error_msg = function() return "err" end,
+        get_local_bookmark_names = function()
+          return {}
+        end,
+        get_all_revisions = function()
+          return {}
+        end,
+        parse_selection = function(s)
+          return s
+        end,
+        error_msg = function()
+          return "err"
+        end,
       },
     }, function(actions)
       local popup = {
-        get_arguments = function() return {} end,
-        get_internal_arguments = function() return {} end,
+        get_arguments = function()
+          return {}
+        end,
+        get_internal_arguments = function()
+          return {}
+        end,
       }
       actions.push(popup)
     end)


### PR DESCRIPTION

<img width="766" height="384" alt="CleanShot 2026-04-27 at 23 53 13@2x" src="https://github.com/user-attachments/assets/16dc48da-575f-428d-bb27-fe88111dd90d" />

## Summary
- jj git push can exit 0 while emitting `Warning:`/`Hint:` lines on stderr (e.g. pushing against a non-tracking remote bookmark prints a warning and `Nothing changed.`). The success toast hid these, so the user saw "Pushed" even when nothing was actually pushed.
- Adds `extract_warnings(stderr)` in `popups/push/actions.lua` that scans for `^Warning:` lines plus their associated `^Hint:` and indented continuation lines.
- When warnings are present on a `code == 0` push, route through `notification.warn` ("Pushed ... with warnings:\n<block>") instead of `notification.info`.

Closes #17.

### Why prefix matching is reliable
Audited jj source (`cli/src/commands/git/push.rs` and the broader CLI). All warnings flow through `ui.warning_default()` → `warning_with_heading("Warning: ")`, all hints through `ui.hint_default()` → `"Hint: "`. Centralized helpers, ~127 callsites, consistent. Multi-line warnings use indented continuation lines, which the helper captures.

## Test plan
- [x] `make test` (10 push specs, all green; full suite green)
- [x] `make lint` (selene + typos clean)
- [ ] Manual repro at `/tmp/neojj-warn/work` (steps below) — without fix shows `Pushed`; with fix shows `Pushed with warnings:` toast containing the Warning + Hint lines
  ```
  rm -rf /tmp/neojj-warn && mkdir -p /tmp/neojj-warn && cd /tmp/neojj-warn \
    && git init --bare remote.git -b main >/dev/null \
    && jj git init --colocate seed >/dev/null \
    && cd seed && git remote add origin /tmp/neojj-warn/remote.git \
    && jj describe -m "first" >/dev/null && jj new -m "shared base" >/dev/null \
    && jj bookmark create bookmark1 -r @- >/dev/null \
    && jj git push --bookmark bookmark1 --allow-new >/dev/null 2>&1 \
    && cd /tmp/neojj-warn && jj git clone --colocate /tmp/neojj-warn/remote.git work >/dev/null 2>&1 \
    && cd work && jj bookmark track bookmark1@origin >/dev/null \
    && jj new bookmark1 -m "moved bookmark1" >/dev/null \
    && jj bookmark set bookmark1 -r @ >/dev/null \
    && jj bookmark untrack bookmark1@origin >/dev/null
  # then `nvim .` in /tmp/neojj-warn/work and trigger the push popup
  ```

## Tradeoffs / scope
- Scoped to push popup. If `fetch` / `rebase` / `bookmark *` show the same UX gap, the helper can be promoted to a shared util — same prefix convention applies repo-wide.
- Hints alone (no preceding `Warning:`) don't trigger the warn path — they're surfaced only as continuation of a warning block.