### PR TITLE
fix(divergent): use jj's authoritative change_offset for /N labels

### DIFF
--- a/lua/neojj/buffers/status/actions.lua
+++ b/lua/neojj/buffers/status/actions.lua
@@ -1186,24 +1186,15 @@ M.n_open_in_browser = function(self)
       return
     end
 
-    local change_id = ctx.change_id or jj.repo.state.head.change_id
+    -- Use commit_id directly: it's unambiguous (a divergent change_id like
+    -- `kumtokwn` resolves to multiple commits and `jj log -r` errors).
+    local commit_hash = (ctx.item and ctx.item.commit_id ~= "" and ctx.item.commit_id)
+      or jj.repo.state.head.commit_id
 
-    if not change_id or change_id == "" then
+    if not commit_hash or commit_hash == "" then
       notification.warn("No change under cursor", { dismiss = true })
       return
     end
-
-    -- Get the git commit hash for this change
-    local result = jj.cli.log.no_graph
-      .template('"" ++ commit_id ++ ""')
-      .revisions(change_id)
-      .limit(1)
-      .call { hidden = true, trim = true }
-    if not result or result.code ~= 0 or not result.stdout[1] then
-      notification.warn("Could not resolve commit", { dismiss = true })
-      return
-    end
-    local commit_hash = result.stdout[1]
 
     local browser_url = get_remote_browser_url()
     if not browser_url then

--- a/lua/neojj/lib/jj/log.lua
+++ b/lua/neojj/lib/jj/log.lua
@@ -143,7 +143,7 @@ end
 
 -- Template that appends immutable/empty/conflict/bookmarks as tab-separated fields after json
 local LIST_TEMPLATE =
-  'json(self) ++ if(immutable, "\\t1", "\\t0") ++ if(empty, "\\t1", "\\t0") ++ if(conflict, "\\t1", "\\t0") ++ if(divergent, "\\t1", "\\t0") ++ "\\t" ++ local_bookmarks.map(|b| b.name()).join(",") ++ "\\t" ++ remote_bookmarks.filter(|b| b.remote() != "git").map(|b| b.name() ++ "@" ++ b.remote()).join(",") ++ "\\t" ++ change_id.shortest(8).prefix() ++ "\\n"'
+  'json(self) ++ if(immutable, "\\t1", "\\t0") ++ if(empty, "\\t1", "\\t0") ++ if(conflict, "\\t1", "\\t0") ++ if(divergent, "\\t1", "\\t0") ++ "\\t" ++ local_bookmarks.map(|b| b.name()).join(",") ++ "\\t" ++ remote_bookmarks.filter(|b| b.remote() != "git").map(|b| b.name() ++ "@" ++ b.remote()).join(",") ++ "\\t" ++ change_id.shortest(8).prefix() ++ "\\t" ++ self.change_offset() ++ "\\n"'
 
 --- Parse lines produced by LIST_TEMPLATE into entries
 ---@param lines string[]
@@ -170,6 +170,12 @@ local function parse_enriched_lines(lines)
           end
           if parts[7] and parts[7] ~= "" then
             entry.shortest_prefix = parts[7]
+          end
+          -- jj's `self.change_offset()` returns 0 for non-divergent commits; only
+          -- carry it through for actual variants so the field's "this is a divergent
+          -- variant" semantics are preserved.
+          if entry.divergent and parts[8] and parts[8] ~= "" then
+            entry.change_offset = tonumber(parts[8])
           end
           table.insert(entries, entry)
         end
@@ -243,11 +249,16 @@ function M.group_divergent(entries)
   for _, indices in pairs(groups) do
     if #indices >= 2 then
       local variants = {}
-      for offset, idx in ipairs(indices) do
-        local v = vim.deepcopy(entries[idx])
-        v.change_offset = offset - 1
-        table.insert(variants, v)
+      for _, idx in ipairs(indices) do
+        table.insert(variants, vim.deepcopy(entries[idx]))
       end
+      -- Sort by jj's authoritative change_offset so the rendered /0, /1, ...
+      -- order matches what `jj log` shows. Falls back to original index when
+      -- offset is missing (shouldn't happen for divergent entries from the
+      -- template, but defensive against older callers that build entries by hand).
+      table.sort(variants, function(a, b)
+        return (a.change_offset or 0) < (b.change_offset or 0)
+      end)
       parent_at[indices[1]] = synthesize_parent(variants)
       for k = 2, #indices do
         removed[indices[k]] = true
@@ -327,7 +338,10 @@ function M.list(revset, limit)
   return M.group_divergent(parse_enriched_lines(result.stdout))
 end
 
----Parse a single line of `jj log -T 'json(self) ++ if(divergent, "\tdivergent", "")'` output.
+---Parse a single line of `jj log -T 'json(self) ++ "\tdivergent\t" ++ N or "\t\t"'` output.
+---Trailing format is `\t<divergent>\t<change_offset>` where `<divergent>` is
+---literally "divergent" or empty, and `<change_offset>` is jj's variant index
+---for divergent commits (empty otherwise).
 ---@param line string
 ---@return NeojjChangeLogEntry
 function M.parse_with_graph_line(line)
@@ -353,7 +367,11 @@ function M.parse_with_graph_line(line)
 
   local entry = M.json_to_entry(obj)
   entry.graph = graph
-  entry.divergent = trailing:find("divergent", 1, true) ~= nil
+  local trailing_parts = vim.split(trailing, "\t", { plain = true })
+  entry.divergent = trailing_parts[2] == "divergent"
+  if entry.divergent and trailing_parts[3] and trailing_parts[3] ~= "" then
+    entry.change_offset = tonumber(trailing_parts[3])
+  end
   entry.immutable = graph:match("◆") ~= nil
   entry.current_working_copy = graph:match("@") ~= nil
   return entry
@@ -369,7 +387,9 @@ function M.list_with_graph(revset, limit)
   local config = require("neojj.config")
   limit = limit or config.values.status.recent_commit_count
 
-  local builder = jj.cli.log.template('json(self) ++ if(divergent, "\\tdivergent", "")')
+  local builder = jj.cli.log.template(
+    'json(self) ++ "\\t" ++ if(divergent, "divergent", "") ++ "\\t" ++ if(divergent, self.change_offset(), "")'
+  )
   if revset and revset ~= "" then
     builder = builder.revisions(revset)
   end
@@ -445,17 +465,16 @@ function meta.update(state)
 
   state.recent.items = M.group_divergent(entries)
 
-  -- Enrich head and parent from log data (description, shortest_prefix)
+  -- Enrich head and parent from log data (description, shortest_prefix).
+  -- Match by commit_id so divergent variants (which share a change_id) resolve
+  -- to the right entry. state.{head,parent}.commit_id is the short prefix from
+  -- `jj status`; entry.commit_id is the full hash from the JSON template.
   if #entries > 0 then
     for _, entry in ipairs(entries) do
-      -- Match head
       if
-        state.head.change_id ~= ""
-        and (
-          entry.change_id == state.head.change_id
-          or state.head.change_id:find(entry.change_id, 1, true) == 1
-          or entry.change_id:find(state.head.change_id, 1, true) == 1
-        )
+        state.head.commit_id ~= ""
+        and entry.commit_id ~= ""
+        and entry.commit_id:find(state.head.commit_id, 1, true) == 1
       then
         if
           entry.description ~= "" and (state.head.description == "" or state.head.description:match("^%("))
@@ -466,14 +485,10 @@ function meta.update(state)
           state.head.shortest_prefix = entry.shortest_prefix
         end
       end
-      -- Match parent
       if
-        state.parent.change_id ~= ""
-        and (
-          entry.change_id == state.parent.change_id
-          or state.parent.change_id:find(entry.change_id, 1, true) == 1
-          or entry.change_id:find(state.parent.change_id, 1, true) == 1
-        )
+        state.parent.commit_id ~= ""
+        and entry.commit_id ~= ""
+        and entry.commit_id:find(state.parent.commit_id, 1, true) == 1
       then
         if entry.shortest_prefix then
           state.parent.shortest_prefix = entry.shortest_prefix

--- a/tests/specs/neojj/lib/jj/log_spec.lua
+++ b/tests/specs/neojj/lib/jj/log_spec.lua
@@ -206,33 +206,51 @@ describe("jj log parser", function()
     end)
 
     it("parses divergent flag (4th flag field)", function()
-      local line = make_line(sample_json, "0\t0\t0\t1\t\t\tmuvq")
+      local line = make_line(sample_json, "0\t0\t0\t1\t\t\tmuvq\t0")
       local entries = log.parse_enriched_lines { line }
       assert.is_true(entries[1].divergent)
     end)
 
     it("defaults divergent to false when flag is 0", function()
-      local line = make_line(sample_json, "0\t0\t0\t0\tmain\t\tmuvq")
+      local line = make_line(sample_json, "0\t0\t0\t0\tmain\t\tmuvq\t0")
       local entries = log.parse_enriched_lines { line }
       assert.is_false(entries[1].divergent)
       assert.are.same({ "main" }, entries[1].bookmarks)
+    end)
+
+    it("parses change_offset (8th tab field) for divergent entries", function()
+      local line = make_line(sample_json, "0\t0\t0\t1\t\t\tmuvq\t2")
+      local entries = log.parse_enriched_lines { line }
+      assert.is_true(entries[1].divergent)
+      assert.are.equal(2, entries[1].change_offset)
+    end)
+
+    it("ignores change_offset for non-divergent entries", function()
+      -- jj's `self.change_offset()` returns 0 for non-divergent commits; we don't
+      -- store it so callers can distinguish "this is a variant" via change_offset != nil.
+      local line = make_line(sample_json, "0\t0\t0\t0\t\t\tmuvq\t0")
+      local entries = log.parse_enriched_lines { line }
+      assert.is_false(entries[1].divergent)
+      assert.is_nil(entries[1].change_offset)
     end)
   end)
 
   describe("list_with_graph parsing helper", function()
     it("parses divergent flag from trailing tab-tag", function()
       local line =
-        '○  {"change_id":"abc","commit_id":"123","description":"x","author":{"name":"","email":"","timestamp":""}}\tdivergent'
+        '○  {"change_id":"abc","commit_id":"123","description":"x","author":{"name":"","email":"","timestamp":""}}\tdivergent\t1'
       local entry = log.parse_with_graph_line(line)
       assert.is_true(entry.divergent)
       assert.are.equal("abc", entry.change_id)
+      assert.are.equal(1, entry.change_offset)
     end)
 
-    it("defaults divergent to false when no tab-tag", function()
+    it("defaults divergent to false when trailing tag is empty", function()
       local line =
-        '○  {"change_id":"abc","commit_id":"123","description":"x","author":{"name":"","email":"","timestamp":""}}'
+        '○  {"change_id":"abc","commit_id":"123","description":"x","author":{"name":"","email":"","timestamp":""}}\t\t'
       local entry = log.parse_with_graph_line(line)
       assert.is_false(entry.divergent)
+      assert.is_nil(entry.change_offset)
     end)
 
     it("returns graph-only entry for connector lines", function()
@@ -277,8 +295,8 @@ describe("jj log parser", function()
 
     it("collapses two divergent entries into a parent + two variants", function()
       local input = {
-        entry { change_id = "x", commit_id = "1", divergent = true, description = "v1" },
-        entry { change_id = "x", commit_id = "2", divergent = true, description = "v2" },
+        entry { change_id = "x", commit_id = "1", divergent = true, change_offset = 0, description = "v1" },
+        entry { change_id = "x", commit_id = "2", divergent = true, change_offset = 1, description = "v2" },
         entry { change_id = "y", commit_id = "3" },
       }
       local out = log.group_divergent(input)
@@ -296,6 +314,29 @@ describe("jj log parser", function()
       assert.are.equal("y", out[2].change_id)
     end)
 
+    it("sorts variants by jj's change_offset, not by parser iteration order", function()
+      -- Graph mode emits @ first, so a divergent variant labelled /1 by jj can
+      -- arrive before /0. Output must still render /0 before /1.
+      local input = {
+        entry {
+          change_id = "x",
+          commit_id = "wc",
+          divergent = true,
+          change_offset = 1,
+          current_working_copy = true,
+        },
+        entry { change_id = "x", commit_id = "other", divergent = true, change_offset = 0 },
+      }
+      local out = log.group_divergent(input)
+      assert.are.equal(1, #out)
+      local parent = out[1]
+      assert.are.equal(2, #parent.variants)
+      assert.are.equal(0, parent.variants[1].change_offset)
+      assert.are.equal("other", parent.variants[1].commit_id)
+      assert.are.equal(1, parent.variants[2].change_offset)
+      assert.are.equal("wc", parent.variants[2].commit_id)
+    end)
+
     it("treats a divergent entry alone in the revset as non-divergent", function()
       local input = {
         entry { change_id = "x", commit_id = "1", divergent = true, description = "lonely" },
@@ -309,9 +350,9 @@ describe("jj log parser", function()
 
     it("handles three variants in order", function()
       local input = {
-        entry { change_id = "x", commit_id = "a", divergent = true },
-        entry { change_id = "x", commit_id = "b", divergent = true },
-        entry { change_id = "x", commit_id = "c", divergent = true },
+        entry { change_id = "x", commit_id = "a", divergent = true, change_offset = 0 },
+        entry { change_id = "x", commit_id = "b", divergent = true, change_offset = 1 },
+        entry { change_id = "x", commit_id = "c", divergent = true, change_offset = 2 },
       }
       local out = log.group_divergent(input)
       assert.are.equal(1, #out)


### PR DESCRIPTION
Closes #12.

## Summary

Fixes two correctness bugs in divergent change handling that surfaced from the work in #14:

1. **`/N` variant labels were wrong.** They were synthesized from parser iteration order, not jj's own offset. In graph mode (where the `@` row floats to the top) this swapped `/0` and `/1`, so a user looking at our UI alongside `jj log` could see the same commit labelled differently in each.
2. **Head/parent description didn't enrich for divergent `@`.** `meta.update` prefix-matched log entries against `state.head.change_id`, but the change_id from `jj status` includes the `/N` suffix (e.g. `kumtokwn/1`) which doesn't prefix-match the bare full change_id from the JSON template. The working copy's description stayed at `(divergent) (empty) ...` placeholder instead of the clean log entry description.

## What changed

- `lib/jj/log.lua`:
  - Added `++ "\t" ++ self.change_offset()` to `LIST_TEMPLATE` and the graph-mode template. jj's `commit.change_offset()` returns the same integer that drives `/N` in default `jj log` output.
  - `parse_enriched_lines` and `parse_with_graph_line` parse the new field, but only set `entry.change_offset` when `divergent` is true (jj returns `0` for non-divergent; we preserve the "nil = not a variant" semantic for the existing `change_offset ~= nil` guards in buffer code).
  - `group_divergent` no longer overwrites `change_offset` with iteration index. It now `table.sort`s variants by jj's offset before handing them to `synthesize_parent`, so `parent.variants[1]` is always `/0`, `[2]` is `/1`, etc.
  - `meta.update` enrichment now matches by `commit_id` prefix instead of `change_id` prefix. Unambiguous even for divergent variants (which share a change_id but not a commit_id).
- `buffers/status/actions.lua` (open-in-browser): drops a redundant `jj log -r <change_id>` resolve. Divergent change_ids error in that command, and we already have `commit_id` on every item — the resolve was just re-emitting it via a template anyway.

## Test plan

- [x] Unit tests in `tests/specs/neojj/lib/jj/log_spec.lua`:
  - Parses `change_offset` from the new 8th tab field; ignores it for non-divergent.
  - Parses the new `\tdivergent\t<offset>` graph-mode trailing tag.
  - Sorts variants by jj's `change_offset` even when the parser receives them in a different order (graph mode emits `@` first).
- [x] Manual test against `/tmp/neojj-divergent-demo` covering:
  - 2-way divergent change with `@` on `/1` (verifies `/N` labels match `jj log`).
  - 4-way divergent change with `@` on a middle variant `/2` (verifies sort).
  - Same change after abandoning `/1` and `/2` — leaves `/0` and `/4` (jj keeps offsets stable across abandons; the gap renders correctly with no fabricated `/1, /2, /3` filler).
  - Bookmarks on individual divergent variants render correctly.
  - Post-abandon `@` on a fresh empty change shows clean description (no `(divergent) (empty)` placeholder).
- [ ] Test against a non-divergent repo to confirm the non-divergent path still renders normally.

## Caveats

- `self.change_offset()` is a jj template method. Tested on jj 0.40.0; older versions may not have it. If you want guaranteed compatibility with older jj, we should either probe at startup or document a minimum jj version. Not addressed here.