### PR TITLE
feat(bookmark): track all combinations of branches and remotes

### DIFF
--- a/lua/neojj/buffers/status/actions.lua
+++ b/lua/neojj/buffers/status/actions.lua
@@ -898,7 +898,7 @@ M.n_forget_bookmark = function(self)
       if not input.get_permission("Track bookmark " .. ref .. "?") then
         return
       end
-      local result = jj.cli.bookmark_track.args(ref).call()
+      local result = jj.cli.bookmark_track.args(name).remote(remote).call()
       if result and result.code == 0 then
         notification.info("Tracking " .. ref, { dismiss = true })
         self:dispatch_refresh(nil, "n_forget_bookmark")
@@ -940,7 +940,7 @@ M.n_new_change_on = function(self)
     local item = ctx.item
     if item and item.remote and item.remote ~= "" and ctx.section == "bookmarks" then
       local ref = item.name .. "@" .. item.remote
-      local track_result = jj.cli.bookmark_track.args(ref).call()
+      local track_result = jj.cli.bookmark_track.args(item.name).remote(item.remote).call()
       if track_result and track_result.code == 0 then
         notification.info("Tracked " .. ref, { dismiss = true })
       end

--- a/lua/neojj/lib/jj/bookmark.lua
+++ b/lua/neojj/lib/jj/bookmark.lua
@@ -127,6 +127,10 @@ end
 ---@param bookmark_at_remote string e.g., "main@origin"
 function M.track(bookmark_at_remote)
   local jj = require("neojj.lib.jj")
+  local name, remote = bookmark_at_remote:match("^(.+)@(.+)$")
+  if name and remote then
+    return jj.cli.bookmark_track.args(name).remote(remote).call()
+  end
   return jj.cli.bookmark_track.args(bookmark_at_remote).call()
 end
 

--- a/lua/neojj/lib/jj/cli.lua
+++ b/lua/neojj/lib/jj/cli.lua
@@ -540,7 +540,11 @@ define_command("bookmark delete", {})
 define_command("bookmark forget", {})
 
 -- jj bookmark track
-define_command("bookmark track", {})
+define_command("bookmark track", {
+  options = {
+    remote = "--remote",
+  },
+})
 
 -- jj bookmark untrack
 define_command("bookmark untrack", {

--- a/lua/neojj/popups/bookmark/actions.lua
+++ b/lua/neojj/popups/bookmark/actions.lua
@@ -175,8 +175,23 @@ function M.forget(_popup)
 end
 
 function M.track(_popup)
-  local bookmarks = picker_cache.get_remote_bookmark_names()
-  local name = FuzzyFinderBuffer.new(bookmarks):open_async { prompt_prefix = "Track bookmark" }
+  local remotes_result = jj.cli.git_remote_list.call { hidden = true, trim = true }
+  local remotes = {}
+  if remotes_result and remotes_result.code == 0 then
+    for _, line in ipairs(remotes_result.stdout or {}) do
+      local remote_name = line:match("^(%S+)")
+      if remote_name then
+        table.insert(remotes, remote_name)
+      end
+    end
+  end
+  local targets = {}
+  for _, branch in ipairs(picker_cache.get_local_bookmark_names()) do
+    for _, remote in ipairs(remotes) do
+      table.insert(targets, branch .. "@" .. remote)
+    end
+  end
+  local name = FuzzyFinderBuffer.new(targets):open_async { prompt_prefix = "Track bookmark" }
   if not name then
     return
   end

--- a/lua/neojj/popups/bookmark/actions.lua
+++ b/lua/neojj/popups/bookmark/actions.lua
@@ -196,7 +196,7 @@ function M.track(_popup)
     return
   end
 
-  local result = jj.cli.bookmark_track.args(name).call()
+  local result = require("neojj.lib.jj.bookmark").track(name)
   if result and result.code == 0 then
     notification.info("Tracking " .. name, { dismiss = true })
   else

--- a/tests/specs/neojj/popups/bookmark/actions_spec.lua
+++ b/tests/specs/neojj/popups/bookmark/actions_spec.lua
@@ -33,10 +33,14 @@ local function base_stubs(overrides)
         bookmark_track = {
           args = function(name)
             return {
-              call = function()
-                return { code = 0, stderr = {} }
-              end,
               _name = name,
+              remote = function()
+                return {
+                  call = function()
+                    return { code = 0, stderr = {} }
+                  end,
+                }
+              end,
             }
           end,
         },
@@ -98,46 +102,56 @@ describe("bookmark track action", function()
     local selections = { "main@origin" }
 
     local tracked_name = nil
+    local tracked_remote = nil
     local track_builder_factory = function(name)
       tracked_name = name
       return {
-        call = function()
-          return { code = 0, stderr = {} }
+        remote = function(r)
+          tracked_remote = r
+          return {
+            call = function()
+              return { code = 0, stderr = {} }
+            end,
+          }
         end,
       }
     end
 
-    with_actions_module(base_stubs({
-      ["neojj.lib.jj"] = {
-        cli = {
-          bookmark_track = { args = track_builder_factory },
-          git_remote_list = {
-            call = function()
-              return { code = 0, stdout = { "origin git@example.com:org/repo.git" } }
-            end,
+    with_actions_module(
+      base_stubs {
+        ["neojj.lib.jj"] = {
+          cli = {
+            bookmark_track = { args = track_builder_factory },
+            git_remote_list = {
+              call = function()
+                return { code = 0, stdout = { "origin git@example.com:org/repo.git" } }
+              end,
+            },
           },
         },
+        ["neojj.buffers.fuzzy_finder"] = {
+          new = function(items)
+            return {
+              open_async = function(_, opts)
+                table.insert(finder_calls, { items = items, prompt_prefix = opts.prompt_prefix })
+                return table.remove(selections, 1)
+              end,
+            }
+          end,
+        },
       },
-      ["neojj.buffers.fuzzy_finder"] = {
-        new = function(items)
-          return {
-            open_async = function(_, opts)
-              table.insert(finder_calls, { items = items, prompt_prefix = opts.prompt_prefix })
-              return table.remove(selections, 1)
-            end,
-          }
-        end,
-      },
-    }), function(actions)
-      actions.track()
-    end)
+      function(actions)
+        actions.track()
+      end
+    )
 
     assert.are.equal(1, #finder_calls)
     assert.are.equal("Track bookmark", finder_calls[1].prompt_prefix)
     local items = finder_calls[1].items
     table.sort(items)
     assert.are.same({ "dev@origin", "main@origin" }, items)
-    assert.are.equal("main@origin", tracked_name)
+    assert.are.equal("main", tracked_name)
+    assert.are.equal("origin", tracked_remote)
   end)
 
   it("builds cross-product for multiple remotes", function()
@@ -145,84 +159,105 @@ describe("bookmark track action", function()
     local selections = { "dev@upstream" }
 
     local tracked_name = nil
+    local tracked_remote = nil
 
-    with_actions_module(base_stubs({
-      ["neojj.lib.jj"] = {
-        cli = {
-          bookmark_track = {
-            args = function(name)
-              tracked_name = name
-              return { call = function() return { code = 0, stderr = {} } end }
-            end,
-          },
-          git_remote_list = {
-            call = function()
-              return {
-                code = 0,
-                stdout = {
-                  "origin git@example.com:org/repo.git",
-                  "upstream git@example.com:upstream/repo.git",
-                },
-              }
-            end,
+    with_actions_module(
+      base_stubs {
+        ["neojj.lib.jj"] = {
+          cli = {
+            bookmark_track = {
+              args = function(name)
+                tracked_name = name
+                return {
+                  remote = function(r)
+                    tracked_remote = r
+                    return {
+                      call = function()
+                        return { code = 0, stderr = {} }
+                      end,
+                    }
+                  end,
+                }
+              end,
+            },
+            git_remote_list = {
+              call = function()
+                return {
+                  code = 0,
+                  stdout = {
+                    "origin git@example.com:org/repo.git",
+                    "upstream git@example.com:upstream/repo.git",
+                  },
+                }
+              end,
+            },
           },
         },
+        ["neojj.buffers.fuzzy_finder"] = {
+          new = function(items)
+            return {
+              open_async = function(_, opts)
+                table.insert(finder_calls, { items = items, prompt_prefix = opts.prompt_prefix })
+                return table.remove(selections, 1)
+              end,
+            }
+          end,
+        },
       },
-      ["neojj.buffers.fuzzy_finder"] = {
-        new = function(items)
-          return {
-            open_async = function(_, opts)
-              table.insert(finder_calls, { items = items, prompt_prefix = opts.prompt_prefix })
-              return table.remove(selections, 1)
-            end,
-          }
-        end,
-      },
-    }), function(actions)
-      actions.track()
-    end)
+      function(actions)
+        actions.track()
+      end
+    )
 
     local items = finder_calls[1].items
     table.sort(items)
     assert.are.same({ "dev@origin", "dev@upstream", "main@origin", "main@upstream" }, items)
-    assert.are.equal("dev@upstream", tracked_name)
+    assert.are.equal("dev", tracked_name)
+    assert.are.equal("upstream", tracked_remote)
   end)
 
   it("aborts when picker is canceled", function()
     local track_called = false
 
-    with_actions_module(base_stubs({
-      ["neojj.lib.jj"] = {
-        cli = {
-          bookmark_track = {
-            args = function()
-              return {
-                call = function()
-                  track_called = true
-                  return { code = 0, stderr = {} }
-                end,
-              }
-            end,
-          },
-          git_remote_list = {
-            call = function()
-              return { code = 0, stdout = { "origin git@example.com:org/repo.git" } }
-            end,
+    with_actions_module(
+      base_stubs {
+        ["neojj.lib.jj"] = {
+          cli = {
+            bookmark_track = {
+              args = function()
+                return {
+                  remote = function()
+                    return {
+                      call = function()
+                        track_called = true
+                        return { code = 0, stderr = {} }
+                      end,
+                    }
+                  end,
+                }
+              end,
+            },
+            git_remote_list = {
+              call = function()
+                return { code = 0, stdout = { "origin git@example.com:org/repo.git" } }
+              end,
+            },
           },
         },
+        ["neojj.buffers.fuzzy_finder"] = {
+          new = function()
+            return {
+              open_async = function()
+                return nil
+              end,
+            }
+          end,
+        },
       },
-      ["neojj.buffers.fuzzy_finder"] = {
-        new = function()
-          return {
-            open_async = function()
-              return nil
-            end,
-          }
-        end,
-      },
-    }), function(actions)
-      actions.track()
-    end)
+      function(actions)
+        actions.track()
+      end
+    )
 
     assert.is_false(track_called)
   end)
@@ -230,34 +265,45 @@ describe("bookmark track action", function()
   it("shows empty picker when no remotes are configured", function()
     local finder_calls = {}
 
-    with_actions_module(base_stubs({
-      ["neojj.lib.jj"] = {
-        cli = {
-          bookmark_track = {
-            args = function()
-              return { call = function() return { code = 0, stderr = {} } end }
-            end,
-          },
-          git_remote_list = {
-            call = function()
-              return { code = 0, stdout = {} }
-            end,
+    with_actions_module(
+      base_stubs {
+        ["neojj.lib.jj"] = {
+          cli = {
+            bookmark_track = {
+              args = function()
+                return {
+                  remote = function()
+                    return {
+                      call = function()
+                        return { code = 0, stderr = {} }
+                      end,
+                    }
+                  end,
+                }
+              end,
+            },
+            git_remote_list = {
+              call = function()
+                return { code = 0, stdout = {} }
+              end,
+            },
           },
         },
+        ["neojj.buffers.fuzzy_finder"] = {
+          new = function(items)
+            return {
+              open_async = function(_, opts)
+                table.insert(finder_calls, { items = items, prompt_prefix = opts.prompt_prefix })
+                return nil
+              end,
+            }
+          end,
+        },
       },
-      ["neojj.buffers.fuzzy_finder"] = {
-        new = function(items)
-          return {
-            open_async = function(_, opts)
-              table.insert(finder_calls, { items = items, prompt_prefix = opts.prompt_prefix })
-              return nil
-            end,
-          }
-        end,
-      },
-    }), function(actions)
-      actions.track()
-    end)
+      function(actions)
+        actions.track()
+      end
+    )
 
     assert.are.equal(1, #finder_calls)
     assert.are.same({}, finder_calls[1].items)
@@ -267,39 +313,50 @@ describe("bookmark track action", function()
     local warn_messages = {}
     local selections = { "main@origin" }
 
-    with_actions_module(base_stubs({
-      ["neojj.lib.jj"] = {
-        cli = {
-          bookmark_track = {
-            args = function()
-              return { call = function() return { code = 1, stderr = { "error" } } end }
-            end,
-          },
-          git_remote_list = {
-            call = function()
-              return { code = 0, stdout = { "origin git@example.com:org/repo.git" } }
-            end,
+    with_actions_module(
+      base_stubs {
+        ["neojj.lib.jj"] = {
+          cli = {
+            bookmark_track = {
+              args = function()
+                return {
+                  remote = function()
+                    return {
+                      call = function()
+                        return { code = 1, stderr = { "error" } }
+                      end,
+                    }
+                  end,
+                }
+              end,
+            },
+            git_remote_list = {
+              call = function()
+                return { code = 0, stdout = { "origin git@example.com:org/repo.git" } }
+              end,
+            },
           },
         },
+        ["neojj.lib.notification"] = {
+          info = function() end,
+          warn = function(msg)
+            table.insert(warn_messages, msg)
+          end,
+        },
+        ["neojj.buffers.fuzzy_finder"] = {
+          new = function()
+            return {
+              open_async = function()
+                return table.remove(selections, 1)
+              end,
+            }
+          end,
+        },
       },
-      ["neojj.lib.notification"] = {
-        info = function() end,
-        warn = function(msg)
-          table.insert(warn_messages, msg)
-        end,
-      },
-      ["neojj.buffers.fuzzy_finder"] = {
-        new = function()
-          return {
-            open_async = function()
-              return table.remove(selections, 1)
-            end,
-          }
-        end,
-      },
-    }), function(actions)
-      actions.track()
-    end)
+      function(actions)
+        actions.track()
+      end
+    )
 
     assert.are.equal(1, #warn_messages)
     assert.is_truthy(warn_messages[1]:find("Failed to track bookmark", 1, true))

--- a/tests/specs/neojj/popups/bookmark/actions_spec.lua
+++ b/tests/specs/neojj/popups/bookmark/actions_spec.lua
@@ -1,0 +1,307 @@
+local MODULE = "neojj.popups.bookmark.actions"
+
+---@param stubs table<string, any>
+---@param fn fun(actions: table)
+local function with_actions_module(stubs, fn)
+  local saved = {}
+  for name, mod in pairs(stubs) do
+    saved[name] = package.loaded[name]
+    package.loaded[name] = mod
+  end
+
+  local saved_subject = package.loaded[MODULE]
+  package.loaded[MODULE] = nil
+
+  local ok, err = pcall(function()
+    local actions = require(MODULE)
+    fn(actions)
+  end)
+
+  package.loaded[MODULE] = saved_subject
+  for name, _ in pairs(stubs) do
+    package.loaded[name] = saved[name]
+  end
+
+  assert.is_true(ok, err)
+end
+
+local function base_stubs(overrides)
+  overrides = overrides or {}
+  local stubs = {
+    ["neojj.lib.jj"] = {
+      cli = {
+        bookmark_track = {
+          args = function(name)
+            return {
+              call = function()
+                return { code = 0, stderr = {} }
+              end,
+              _name = name,
+            }
+          end,
+        },
+        git_remote_list = {
+          call = function()
+            return { code = 0, stdout = { "origin git@example.com:org/repo.git" } }
+          end,
+        },
+      },
+    },
+    ["neojj.lib.notification"] = {
+      info = function() end,
+      warn = function() end,
+    },
+    ["neojj.lib.input"] = {
+      get_user_input = function()
+        return nil
+      end,
+      get_permission = function()
+        return false
+      end,
+    },
+    ["neojj.lib.picker_cache"] = {
+      get_local_bookmark_names = function()
+        return { "main", "dev" }
+      end,
+      get_remote_bookmark_names = function()
+        return { "main@origin" }
+      end,
+      get_all_revisions = function()
+        return {}
+      end,
+      parse_selection = function(s)
+        return s
+      end,
+      error_msg = function()
+        return "err"
+      end,
+    },
+    ["neojj.buffers.fuzzy_finder"] = overrides["neojj.buffers.fuzzy_finder"] or {
+      new = function()
+        return {
+          open_async = function()
+            return nil
+          end,
+        }
+      end,
+    },
+  }
+  for k, v in pairs(overrides) do
+    stubs[k] = v
+  end
+  return stubs
+end
+
+describe("bookmark track action", function()
+  it("shows cross-product of local bookmarks and remotes in picker", function()
+    local finder_calls = {}
+    local selections = { "main@origin" }
+
+    local tracked_name = nil
+    local track_builder_factory = function(name)
+      tracked_name = name
+      return {
+        call = function()
+          return { code = 0, stderr = {} }
+        end,
+      }
+    end
+
+    with_actions_module(base_stubs({
+      ["neojj.lib.jj"] = {
+        cli = {
+          bookmark_track = { args = track_builder_factory },
+          git_remote_list = {
+            call = function()
+              return { code = 0, stdout = { "origin git@example.com:org/repo.git" } }
+            end,
+          },
+        },
+      },
+      ["neojj.buffers.fuzzy_finder"] = {
+        new = function(items)
+          return {
+            open_async = function(_, opts)
+              table.insert(finder_calls, { items = items, prompt_prefix = opts.prompt_prefix })
+              return table.remove(selections, 1)
+            end,
+          }
+        end,
+      },
+    }), function(actions)
+      actions.track()
+    end)
+
+    assert.are.equal(1, #finder_calls)
+    assert.are.equal("Track bookmark", finder_calls[1].prompt_prefix)
+    local items = finder_calls[1].items
+    table.sort(items)
+    assert.are.same({ "dev@origin", "main@origin" }, items)
+    assert.are.equal("main@origin", tracked_name)
+  end)
+
+  it("builds cross-product for multiple remotes", function()
+    local finder_calls = {}
+    local selections = { "dev@upstream" }
+
+    local tracked_name = nil
+
+    with_actions_module(base_stubs({
+      ["neojj.lib.jj"] = {
+        cli = {
+          bookmark_track = {
+            args = function(name)
+              tracked_name = name
+              return { call = function() return { code = 0, stderr = {} } end }
+            end,
+          },
+          git_remote_list = {
+            call = function()
+              return {
+                code = 0,
+                stdout = {
+                  "origin git@example.com:org/repo.git",
+                  "upstream git@example.com:upstream/repo.git",
+                },
+              }
+            end,
+          },
+        },
+      },
+      ["neojj.buffers.fuzzy_finder"] = {
+        new = function(items)
+          return {
+            open_async = function(_, opts)
+              table.insert(finder_calls, { items = items, prompt_prefix = opts.prompt_prefix })
+              return table.remove(selections, 1)
+            end,
+          }
+        end,
+      },
+    }), function(actions)
+      actions.track()
+    end)
+
+    local items = finder_calls[1].items
+    table.sort(items)
+    assert.are.same({ "dev@origin", "dev@upstream", "main@origin", "main@upstream" }, items)
+    assert.are.equal("dev@upstream", tracked_name)
+  end)
+
+  it("aborts when picker is canceled", function()
+    local track_called = false
+
+    with_actions_module(base_stubs({
+      ["neojj.lib.jj"] = {
+        cli = {
+          bookmark_track = {
+            args = function()
+              return {
+                call = function()
+                  track_called = true
+                  return { code = 0, stderr = {} }
+                end,
+              }
+            end,
+          },
+          git_remote_list = {
+            call = function()
+              return { code = 0, stdout = { "origin git@example.com:org/repo.git" } }
+            end,
+          },
+        },
+      },
+      ["neojj.buffers.fuzzy_finder"] = {
+        new = function()
+          return {
+            open_async = function()
+              return nil
+            end,
+          }
+        end,
+      },
+    }), function(actions)
+      actions.track()
+    end)
+
+    assert.is_false(track_called)
+  end)
+
+  it("shows empty picker when no remotes are configured", function()
+    local finder_calls = {}
+
+    with_actions_module(base_stubs({
+      ["neojj.lib.jj"] = {
+        cli = {
+          bookmark_track = {
+            args = function()
+              return { call = function() return { code = 0, stderr = {} } end }
+            end,
+          },
+          git_remote_list = {
+            call = function()
+              return { code = 0, stdout = {} }
+            end,
+          },
+        },
+      },
+      ["neojj.buffers.fuzzy_finder"] = {
+        new = function(items)
+          return {
+            open_async = function(_, opts)
+              table.insert(finder_calls, { items = items, prompt_prefix = opts.prompt_prefix })
+              return nil
+            end,
+          }
+        end,
+      },
+    }), function(actions)
+      actions.track()
+    end)
+
+    assert.are.equal(1, #finder_calls)
+    assert.are.same({}, finder_calls[1].items)
+  end)
+
+  it("shows warning on track failure", function()
+    local warn_messages = {}
+    local selections = { "main@origin" }
+
+    with_actions_module(base_stubs({
+      ["neojj.lib.jj"] = {
+        cli = {
+          bookmark_track = {
+            args = function()
+              return { call = function() return { code = 1, stderr = { "error" } } end }
+            end,
+          },
+          git_remote_list = {
+            call = function()
+              return { code = 0, stdout = { "origin git@example.com:org/repo.git" } }
+            end,
+          },
+        },
+      },
+      ["neojj.lib.notification"] = {
+        info = function() end,
+        warn = function(msg)
+          table.insert(warn_messages, msg)
+        end,
+      },
+      ["neojj.buffers.fuzzy_finder"] = {
+        new = function()
+          return {
+            open_async = function()
+              return table.remove(selections, 1)
+            end,
+          }
+        end,
+      },
+    }), function(actions)
+      actions.track()
+    end)
+
+    assert.are.equal(1, #warn_messages)
+    assert.is_truthy(warn_messages[1]:find("Failed to track bookmark", 1, true))
+  end)
+end)


### PR DESCRIPTION
Closes #19.

After carefully thinking about the tradeoffs I think being explicit for all remotes would be better than adding the implicit/default remote to the picker.

Used Copilot for assistance in test writing.

Also tested locally when publishing this branch.