### PR TITLE
feat: add support for tracking and untracking files

### DIFF
--- a/lua/neojj/buffers/status/actions.lua
+++ b/lua/neojj/buffers/status/actions.lua
@@ -454,6 +454,46 @@ end
 
 ---@param self StatusBuffer
 ---@return fun(): nil
+M.n_file_track = function(self)
+  return a.void(function()
+    local selection = self.buffer.ui:get_selection()
+    if not selection.section then
+      return
+    end
+
+    local section = selection.section.name
+    if section ~= "untracked" then
+      return
+    end
+
+    if selection.item and selection.item.first == fn.line(".") then
+      -- track single file
+      jj.cli.file_track.files(selection.item.fileset_path).call()
+    else
+      -- track all untracked files
+      jj.cli.file_track.files("./").call()
+    end
+    self:dispatch_refresh(nil, "n_file_track")
+  end)
+end
+
+---@param self StatusBuffer
+---@return fun(): nil
+M.n_file_untrack = function(self)
+  return a.void(function()
+    local ctx = cursor_context(self)
+    if not ctx.section then
+      return
+    end
+    if ctx.section == "files" and ctx.item then
+      jj.cli.file_untrack.files(ctx.item.fileset_path).call()
+      self:dispatch_refresh(nil, "n_file_untrack")
+    end
+  end)
+end
+
+---@param self StatusBuffer
+---@return fun(): nil
 M.n_context_delete = function(self)
   return a.void(function()
     local ctx = cursor_context(self)

--- a/lua/neojj/buffers/status/init.lua
+++ b/lua/neojj/buffers/status/init.lua
@@ -195,6 +195,8 @@ function M:open(kind)
         ["O"]                                   = self:_action("n_new_change_on"),
         ["B"]                                   = self:_action("n_new_change_before"),
         ["dd"]                                  = self:_action("n_open_variant_diff"),
+        [mappings["Track"]]                     = self:_action("n_file_track"),
+        [mappings["Untrack"]]                   = self:_action("n_file_untrack"),
         -- jj popup bindings
         [popups.mapping_for("CommitPopup")]     = self:_action("n_commit_popup"),
         [popups.mapping_for("DiffPopup")]       = self:_action("n_diff_popup"),

--- a/lua/neojj/buffers/status/ui.lua
+++ b/lua/neojj/buffers/status/ui.lua
@@ -409,10 +409,21 @@ local SectionItemConflict = Component.new(function(item)
 end)
 
 function M.Status(state, config)
+  local is_tracked = function(item)
+    return item.mode ~= "?"
+  end
+  
   -- stylua: ignore start
   local show_hint = not config.disable_hint
 
-  local show_files = state.files and #state.files.items > 0
+  local tracked_files = state.files and vim.tbl_filter(is_tracked, state.files.items)
+  local show_files = tracked_files and #tracked_files > 0
+
+  local untracked_files = state.files and vim.tbl_filter(function (item)
+    return not is_tracked(item)
+  end, state.files.items)
+  local untracked_hidden = config.sections and config.sections.untracked and config.sections.untracked.hidden
+  local show_untracked = untracked_files and #untracked_files > 0  and not untracked_hidden
 
   local show_conflicts = state.conflicts and #state.conflicts.items > 0
 
@@ -470,9 +481,17 @@ function M.Status(state, config)
           title = SectionTitle { title = "Modified files", highlight = "NeojjSectionFiles" },
           count = true,
           render = SectionItemFile("files", config),
-          items = state.files.items,
+          items = tracked_files,
           folded = false,
           name = "files",
+        },
+        show_untracked and Section {
+          title = SectionTitle { title = "Untracked files", highlight = "NeojjSectionFiles" },
+          count = true,
+          render = SectionItemFile("untracked", config),
+          items = untracked_files,
+          folded = config.sections and config.sections.untracked and config.sections.untracked.folded,
+          name = "untracked",
         },
         show_recent and Section {
           title = SectionTitle { title = "Recent Changes", highlight = "NeojjSectionRecent" },

--- a/lua/neojj/config.lua
+++ b/lua/neojj/config.lua
@@ -189,6 +189,7 @@ end
 ---| "Depth4"
 ---| "Toggle"
 ---| "Discard"
+---| "Track"
 ---| "Untrack"
 ---| "RefreshBuffer"
 ---| "GoToFile"
@@ -525,6 +526,7 @@ function M.get_default_values()
         ["zc"] = "CloseFold",
         ["zC"] = "Depth1",
         ["zO"] = "Depth4",
+        ["T"] = "Track",
         ["x"] = "Discard",
         ["K"] = "Untrack",
         ["R"] = "Rename",

--- a/lua/neojj/lib/jj/cli.lua
+++ b/lua/neojj/lib/jj/cli.lua
@@ -104,6 +104,7 @@ local runner = require("neojj.runner")
 ---@field revert NeojjCliBuilder
 ---@field diffedit NeojjCliBuilder
 ---@field file_list NeojjCliBuilder
+---@field file_track NeojjCliBuilder
 ---@field file_untrack NeojjCliBuilder
 ---@field file_annotate NeojjCliBuilder
 ---@field file_show NeojjCliBuilder
@@ -668,6 +669,9 @@ define_command("file list", {
 
 -- jj file untrack
 define_command("file untrack", {})
+
+-- jj file track
+define_command("file track", {})
 
 -- jj file annotate
 define_command("file annotate", {})

--- a/lua/neojj/lib/jj/repository.lua
+++ b/lua/neojj/lib/jj/repository.lua
@@ -19,7 +19,7 @@
 ---@field absolute_path string Full file path
 ---@field escaped_path string Vim-escaped path
 ---@field fileset_path string jj fileset-safe path (file: prefixed)
----@field mode string "M", "A", "D", "R"
+---@field mode string "M", "A", "D", "R", "?" (untracked)
 ---@field original_name string|nil For renames
 ---@field diff any|nil Lazy-loaded diff
 ---@field folded boolean|nil

--- a/lua/neojj/lib/jj/status.lua
+++ b/lua/neojj/lib/jj/status.lua
@@ -50,10 +50,10 @@ function M.parse_status_files(lines, root)
   local in_changes = false
 
   for _, line in ipairs(lines) do
-    if line:match("^Working copy changes:") then
+    if line:match("^Working copy changes:") or line:match("^Untracked paths:") then
       in_changes = true
     elseif in_changes then
-      local mode, name = line:match("^(%a)%s+(.+)$")
+      local mode, name = line:match("^([%a?])%s+(.+)$")
       if mode and name then
         table.insert(items, {
           name = name,

--- a/tests/specs/neojj/buffers/status_spec.lua
+++ b/tests/specs/neojj/buffers/status_spec.lua
@@ -1,0 +1,55 @@
+local config = require("neojj.config")
+local harness = require("tests.util.jj_harness")
+local StatusBuffer = require("neojj.buffers.status")
+
+local function skip_if_no_jj()
+  if not harness.jj_available() then
+    pending("jj binary not available; skipping status buffer test")
+    return true
+  end
+  return false
+end
+
+describe("status buffer mappings", function()
+  local status
+  local working_dir
+
+  before_each(function()
+    config.values = config.get_default_values()
+    config.values.filewatcher.enabled = false
+  end)
+
+  after_each(function()
+    if status then
+      pcall(function()
+        status:close()
+      end)
+    end
+    status = nil
+  end)
+
+  it("uses configured Track and Untrack bindings from the status mapping table", function()
+    if skip_if_no_jj() then
+      return
+    end
+
+    config.values.mappings.status["tt"] = "Track"
+    config.values.mappings.status["uu"] = "Untrack"
+    config.values.mappings.status["T"] = false
+    config.values.mappings.status["K"] = false
+
+    working_dir = harness.prepare_repository { cd = true }
+    status = StatusBuffer.new(config.values, working_dir, working_dir):open("replace")
+
+    local keymaps = vim.api.nvim_buf_get_keymap(status.buffer.handle, "n")
+    local lhses = {}
+    for _, keymap in ipairs(keymaps) do
+      lhses[keymap.lhs] = true
+    end
+
+    assert.is_true(lhses["tt"])
+    assert.is_true(lhses["uu"])
+    assert.is_nil(lhses["T"])
+    assert.is_nil(lhses["K"])
+  end)
+end)

--- a/tests/specs/neojj/config_spec.lua
+++ b/tests/specs/neojj/config_spec.lua
@@ -427,6 +427,13 @@ describe("NeoJJ config", function()
           }
           assert.True(vim.tbl_count(require("neojj.config").validate_config()) ~= 0)
         end)
+
+        it("should return valid when a command mapping uses Track", function()
+          config.values.mappings.status = {
+            ["T"] = "Track",
+          }
+          assert.True(vim.tbl_count(require("neojj.config").validate_config()) == 0)
+        end)
       end)
 
       describe("popup mappings", function()
@@ -589,6 +596,11 @@ describe("NeoJJ config", function()
           print("custom function")
         end
         assert.True(vim.tbl_count(require("neojj.config").validate_config()) == 0)
+      end)
+
+      it("should default Track and Untrack to T and K", function()
+        assert.are.equal("Track", config.values.mappings.status["T"])
+        assert.are.equal("Untrack", config.values.mappings.status["K"])
       end)
 
       it("should return valid when a command mappings.finder is a boolean", function()

--- a/tests/specs/neojj/integration/file_tracking_integration_spec.lua
+++ b/tests/specs/neojj/integration/file_tracking_integration_spec.lua
@@ -1,0 +1,95 @@
+local harness = require("tests.util.jj_harness")
+local Repo = require("neojj.lib.jj.repository").Repo
+local jj = require("neojj.lib.jj")
+
+local function skip_if_no_jj()
+  if not harness.jj_available() then
+    pending("jj binary not available; skipping integration test")
+    return true
+  end
+  return false
+end
+
+local function find_file(items, name)
+  for _, item in ipairs(items) do
+    if item.name == name then
+      return item
+    end
+  end
+end
+
+local modes = {
+  { name = "colocated", colocated = true },
+  { name = "non-colocated", colocated = false },
+}
+
+for _, mode in ipairs(modes) do
+  describe("file tracking integration — " .. mode.name, function()
+    local repo
+    local working_dir
+
+    before_each(function()
+      if skip_if_no_jj() then
+        return
+      end
+      working_dir = harness.prepare_repository { colocated = mode.colocated, auto_track = false }
+      repo = Repo.new(working_dir)
+      repo:refresh()
+    end)
+
+    it("shows untracked files when auto_track is disabled", function()
+      if skip_if_no_jj() then
+        return
+      end
+
+      local untracked = find_file(repo.state.files.items, "untracked.txt")
+      assert.is_not_nil(untracked)
+      assert.are.equal("?", untracked.mode)
+    end)
+
+    it("tracks an untracked file with jj file track", function()
+      if skip_if_no_jj() then
+        return
+      end
+
+      local result = jj.cli.file_track.files("file:untracked.txt").call { await = true, ignore_error = true }
+      assert.is_not_nil(result)
+      assert.are.equal(0, result.code)
+
+      repo:refresh()
+
+      local tracked = find_file(repo.state.files.items, "untracked.txt")
+      assert.is_not_nil(tracked)
+      assert.are.equal("A", tracked.mode)
+    end)
+
+    it("untracks an ignored tracked file with jj file untrack", function()
+      if skip_if_no_jj() then
+        return
+      end
+
+      vim.fn.writefile({ "tracked then ignored" }, working_dir .. "/ignored.txt")
+
+      local track_result = jj.cli.file_track.files("file:ignored.txt").call { await = true, ignore_error = true }
+      assert.is_not_nil(track_result)
+      assert.are.equal(0, track_result.code)
+
+      vim.fn.writefile({ "ignored.txt" }, working_dir .. "/.gitignore")
+
+      repo:refresh()
+
+      local tracked = find_file(repo.state.files.items, "ignored.txt")
+      assert.is_not_nil(tracked)
+      assert.are.equal("A", tracked.mode)
+
+      local result = jj.cli.file_untrack.files("file:ignored.txt").call { await = true, ignore_error = true }
+      assert.is_not_nil(result)
+      assert.are.equal(0, result.code)
+
+      repo:refresh()
+
+      assert.is_nil(find_file(repo.state.files.items, "ignored.txt"))
+      assert.are.equal(1, vim.fn.filereadable(working_dir .. "/ignored.txt"))
+    end)
+  end)
+end

--- a/tests/util/jj_harness.lua
+++ b/tests/util/jj_harness.lua
@@ -4,6 +4,7 @@ local util = require("tests.util.util")
 ---@class JjPrepareOpts
 ---@field colocated boolean|nil  Create a colocated jj+git repo (default: false)
 ---@field cd boolean|nil         chdir into the workspace (default: true)
+---@field auto_track boolean|nil Configure repo snapshot.auto-track (default: true)
 
 ---Create a fresh jj workspace with some committed history.
 ---@param opts JjPrepareOpts|nil
@@ -40,6 +41,19 @@ function M.prepare_repository(opts)
     "test@neojj-test.test",
   }
   util.system { "jj", "--repository", working_dir, "config", "set", "--repo", "user.name", "NeoJJ Test" }
+  local auto_track = opts.auto_track ~= false and "all()" or "none()"
+  -- Keep file tracking deterministic even when the user's global jj config
+  -- would otherwise override the repository's snapshot behavior.
+  util.system {
+    "jj",
+    "--repository",
+    working_dir,
+    "config",
+    "set",
+    "--repo",
+    "snapshot.auto-track",
+    auto_track,
+  }
 
   vim.fn.writefile({ "line 1", "line 2", "line 3" }, working_dir .. "/a.txt")
   vim.fn.writefile({ "hello world" }, working_dir .. "/b.txt")


### PR DESCRIPTION
Hi there, thanks for porting neogit to neojj!

In my `jj` setup, I disable auto tracking of files and thus needed a way to manually track and untrack files in neojj.

I have added a new section to the status buffer along with 2 keybindings to track and untrack files. The default keybinds are `T` for track and `K` for untrack (the untrack keybinding had already existed but was not wired up).

Changes made:

1. Extend the status parser to account for untracked files - they have a mode of `?`
    
    - For now, both tracked and untracked files are all put in the same `state.files` with filtering applied in `M.status`. It is probably possible to store them separately, but I figured that conceptually they are all files so I left it as is for now. 
3. Add status buffer actions `n_file_track` and `n_file_untrack`. 

    - When executed on the header, it will track all untracked files.  
4. Improve the test harness so that it will explicitly set the `snapshot.auto-track` on the test repository so that tests will pass on a system with `auto-track` disabled by default.
   
Let me know what you think, thanks!