### PR TITLE
feat: annotate bookmarks with open PRs and open them with "o"

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,15 @@ neojj.setup {
   -- Which diff viewer to use. nil = auto-detect (tries diffview first, then codediff).
   -- Can be "diffview" or "codediff".
   diff_viewer = nil,
+  -- Forge (GitHub, ...) integration. When enabled and the forge CLI (`gh`) is
+  -- installed, bookmarks with a matching open PR are annotated with the PR
+  -- number, and "o" on such a line opens the PR instead of the commit.
+  forge = {
+    pr_integration = true,
+    -- Extra remote hosts per provider, e.g. for GitHub Enterprise:
+    -- hosts = { github = { "git.yourcompany.com" } },
+    hosts = {},
+  },
   sections = {
     files = {
       folded = false,
@@ -459,7 +468,7 @@ These keybindings work directly in the status buffer on whatever is under your c
 | `O` | **New change on** | Create a new change on top of the revision under cursor |
 | `B` | **New change before** | Insert a new change before the revision under cursor |
 | `F` | **Forget bookmark** | Forget the bookmark under cursor (or track a remote bookmark) |
-| `o` | **Open in browser** | Open the commit under cursor on GitHub/GitLab |
+| `o` | **Open in browser** | Open the line under cursor on GitHub/GitLab: the repo on the project header, the open PR on a line annotated with one, otherwise the commit |
 | `x` | **Discard / Abandon** | Discard file changes, abandon the change (or divergent variant) under cursor, or delete a bookmark under cursor |
 
 > [!NOTE]

--- a/doc/neojj.txt
+++ b/doc/neojj.txt
@@ -225,6 +225,14 @@ the available options with their defaults: >lua
       -- Which diff viewer to use (nil = auto-detect)
       diff_viewer = nil,
 
+      -- Forge (GitHub, ...) integration: annotate bookmarks with open PRs
+      -- and let "o" open the PR in the browser. Requires the forge CLI
+      -- (`gh`) to be installed; disabled silently otherwise.
+      forge = {
+        pr_integration = true,
+        hosts = {},  -- e.g. { github = { "git.yourcompany.com" } }
+      },
+
       -- Section visibility and fold state
       sections = {
         modified = {

--- a/lua/neojj/buffers/commit_view/init.lua
+++ b/lua/neojj/buffers/commit_view/init.lua
@@ -251,6 +251,11 @@ end
 local function diff_visit_file(self, component, worktree)
   local hunk_component = component.parent.parent
   local hunk = hunk_component.options.hunk
+  if not hunk then
+    notification.warn("Unable to determine hunk for diff line")
+    return
+  end
+
   local path = vim.trim(hunk.file)
   if path == "" then
     notification.warn("Unable to determine file path for diff line")

--- a/lua/neojj/buffers/common.lua
+++ b/lua/neojj/buffers/common.lua
@@ -212,6 +212,7 @@ function M.DivergentVariantRow(variant, opts)
   }
 
   local row_opts = {
+    kind = "change",
     yankable = variant.commit_id,
     oid = variant.commit_id,
     item = variant,
@@ -266,6 +267,7 @@ M.CommitEntry = Component.new(function(commit, _remotes, args)
     end
 
     return col.tag("divergent_parent")(vim.list_extend({ row(parent_children) }, variant_rows), {
+      kind = "change",
       item = commit,
       oid = commit.change_id,
       foldable = false,
@@ -366,6 +368,7 @@ M.CommitEntry = Component.new(function(commit, _remotes, args)
     ),
     details,
   }, {
+    kind = "change",
     item = commit,
     oid = commit.change_id,
     foldable = args.details == true,

--- a/lua/neojj/buffers/status/actions.lua
+++ b/lua/neojj/buffers/status/actions.lua
@@ -1080,6 +1080,27 @@ M.n_workspace_popup = function(_self)
   return popups.open("workspace")
 end
 
+---Bookmark names rendered on the line under the cursor.
+---@param ctx table
+---@return string[]
+local function bookmarks_under_cursor(ctx)
+  if ctx.section == "bookmarks" and ctx.item and ctx.item.name then
+    return { ctx.item.name }
+  end
+
+  if ctx.item and ctx.item.bookmarks then
+    return ctx.item.bookmarks
+  end
+
+  for _, head in ipairs { jj.repo.state.head, jj.repo.state.parent } do
+    if ctx.change_id and ctx.change_id == head.change_id then
+      return head.bookmarks or {}
+    end
+  end
+
+  return {}
+end
+
 ---@param self StatusBuffer
 ---@return fun(): nil
 M.n_open_in_browser = function(self)
@@ -1089,45 +1110,27 @@ M.n_open_in_browser = function(self)
       return
     end
 
-    -- Helper to resolve remote URL
-    local function get_remote_browser_url()
-      local shell = require("neojj.lib.jj.shell")
-      local remote_lines, code = shell.exec(
-        { "jj", "--no-pager", "--color=never", "git", "remote", "list" },
-        jj.repo.state.worktree_root
-      )
-      if code ~= 0 or not remote_lines or #remote_lines == 0 then
-        return nil
-      end
-
-      local remote_url
-      for _, line in ipairs(remote_lines) do
-        local url = line:match("^%S+%s+(%S+)")
-        if url then
-          remote_url = url
-          break
-        end
-      end
-
-      if not remote_url then
-        return nil
-      end
-
-      return remote_url
-        :gsub("%.git$", "")
-        :gsub("^git@([^:]+):", "https://%1/")
-        :gsub("^ssh://git@([^/]+)/", "https://%1/")
-    end
+    local remote = require("neojj.lib.jj.remote")
+    local info = remote.get(jj.repo.state.worktree_root)
 
     -- Project header: open repo URL directly
     if ctx.yank == "__project__" then
-      local browser_url = get_remote_browser_url()
-      if not browser_url then
+      if not info then
         notification.warn("No remote found", { dismiss = true })
         return
       end
-      vim.ui.open(browser_url)
+      vim.ui.open(info.browser_url)
       return
+    end
+
+    -- A line annotated with an open PR opens the PR
+    local forge = require("neojj.lib.forge")
+    for _, bookmark in ipairs(bookmarks_under_cursor(ctx)) do
+      local pr = forge.pr_for_branch(jj.repo.state.worktree_root, bookmark)
+      if pr then
+        vim.ui.open(pr.url)
+        return
+      end
     end
 
     -- Use commit_id directly: it's unambiguous (a divergent change_id like
@@ -1140,16 +1143,13 @@ M.n_open_in_browser = function(self)
       return
     end
 
-    local browser_url = get_remote_browser_url()
-    if not browser_url then
+    if not info then
       notification.warn("No remote found", { dismiss = true })
       return
     end
 
     -- Construct commit URL (works for GitHub, GitLab, etc.)
-    browser_url = browser_url .. "/commit/" .. commit_hash
-
-    vim.ui.open(browser_url)
+    vim.ui.open(info.browser_url .. "/commit/" .. commit_hash)
   end
 end
 

--- a/lua/neojj/buffers/status/actions.lua
+++ b/lua/neojj/buffers/status/actions.lua
@@ -11,18 +11,22 @@ local common = require("neojj.buffers.common")
 local fn = vim.fn
 
 ---@class CursorContext
----@field change_id string|nil The change ID under cursor (from item, yankable, or head fallback)
+---@field kind UiContextKind|nil Semantic kind of the line under cursor
+---@field change_id string|nil The change ID under cursor (from item or the line's context node)
+---@field commit_id string|nil The commit ID under cursor (from item or the line's context node)
+---@field bookmarks string[] Bookmark names rendered on the line
 ---@field section string|nil Section name (e.g. "files", "recent", "bookmarks")
 ---@field item StatusItem|nil The item under cursor (from get_selection)
 ---@field yank string|nil Raw yankable value under cursor
 ---@field immutable boolean Whether the change is immutable
 
 --- Resolve cursor context into a structured result.
---- Extracts change_id from item > yankable (head/parent) > nil.
+--- Extracts change_id from item > the line's context node (head/parent headers) > nil.
 ---@param self StatusBuffer
 ---@return CursorContext
 local function cursor_context(self)
   local selection = self.buffer.ui:get_selection()
+  local ui_ctx = self.buffer.ui:context_under_cursor()
   local item = selection.item
   local section = selection.section and selection.section.name
   local yank = self.buffer.ui:get_yankable_under_cursor()
@@ -30,12 +34,22 @@ local function cursor_context(self)
   local change_id
   if item and item.change_id then
     change_id = item.change_id
-  elseif yank and (yank == jj.repo.state.head.change_id or yank == jj.repo.state.parent.change_id) then
-    change_id = yank
+  elseif ui_ctx then
+    change_id = ui_ctx.change_id
+  end
+
+  local commit_id
+  if item and item.commit_id and item.commit_id ~= "" then
+    commit_id = item.commit_id
+  elseif ui_ctx then
+    commit_id = ui_ctx.commit_id
   end
 
   return {
+    kind = ui_ctx and ui_ctx.kind or nil,
     change_id = change_id,
+    commit_id = commit_id,
+    bookmarks = ui_ctx and ui_ctx.bookmarks or {},
     section = section,
     item = item,
     yank = yank,
@@ -1080,27 +1094,6 @@ M.n_workspace_popup = function(_self)
   return popups.open("workspace")
 end
 
----Bookmark names rendered on the line under the cursor.
----@param ctx table
----@return string[]
-local function bookmarks_under_cursor(ctx)
-  if ctx.section == "bookmarks" and ctx.item and ctx.item.name then
-    return { ctx.item.name }
-  end
-
-  if ctx.item and ctx.item.bookmarks then
-    return ctx.item.bookmarks
-  end
-
-  for _, head in ipairs { jj.repo.state.head, jj.repo.state.parent } do
-    if ctx.change_id and ctx.change_id == head.change_id then
-      return head.bookmarks or {}
-    end
-  end
-
-  return {}
-end
-
 ---@param self StatusBuffer
 ---@return fun(): nil
 M.n_open_in_browser = function(self)
@@ -1114,7 +1107,7 @@ M.n_open_in_browser = function(self)
     local info = remote.get(jj.repo.state.worktree_root)
 
     -- Project header: open repo URL directly
-    if ctx.yank == "__project__" then
+    if ctx.kind == "project" then
       if not info then
         notification.warn("No remote found", { dismiss = true })
         return
@@ -1125,7 +1118,7 @@ M.n_open_in_browser = function(self)
 
     -- A line annotated with an open PR opens the PR
     local forge = require("neojj.lib.forge")
-    for _, bookmark in ipairs(bookmarks_under_cursor(ctx)) do
+    for _, bookmark in ipairs(ctx.bookmarks) do
       local pr = forge.pr_for_branch(jj.repo.state.worktree_root, bookmark)
       if pr then
         vim.ui.open(pr.url)
@@ -1135,8 +1128,7 @@ M.n_open_in_browser = function(self)
 
     -- Use commit_id directly: it's unambiguous (a divergent change_id like
     -- `kumtokwn` resolves to multiple commits and `jj log -r` errors).
-    local commit_hash = (ctx.item and ctx.item.commit_id ~= "" and ctx.item.commit_id)
-      or jj.repo.state.head.commit_id
+    local commit_hash = ctx.commit_id or jj.repo.state.head.commit_id
 
     if not commit_hash or commit_hash == "" then
       notification.warn("No change under cursor", { dismiss = true })

--- a/lua/neojj/buffers/status/init.lua
+++ b/lua/neojj/buffers/status/init.lua
@@ -285,9 +285,10 @@ function M:refresh(partial, reason)
     view = self.buffer:save_view()
   end
 
-  -- Runs concurrently with the jj refresh; redraws once (and only if) fresh
-  -- PR data arrives so bookmark annotations appear without blocking the UI.
-  require("neojj.lib.forge").refresh(self.root, function()
+  -- Runs concurrently with the jj refresh; redraws only if the PR data
+  -- changed so bookmark annotations appear without blocking the UI.
+  -- A manual refresh busts the forge TTL cache.
+  require("neojj.lib.forge").refresh(self.root, { force = reason == "n_refresh_buffer" }, function()
     local pr_cursor, pr_view
     if self.buffer and self.buffer:is_focused() then
       pr_cursor = self.buffer.ui:get_cursor_location()

--- a/lua/neojj/buffers/status/init.lua
+++ b/lua/neojj/buffers/status/init.lua
@@ -285,6 +285,17 @@ function M:refresh(partial, reason)
     view = self.buffer:save_view()
   end
 
+  -- Runs concurrently with the jj refresh; redraws once (and only if) fresh
+  -- PR data arrives so bookmark annotations appear without blocking the UI.
+  require("neojj.lib.forge").refresh(self.root, function()
+    local pr_cursor, pr_view
+    if self.buffer and self.buffer:is_focused() then
+      pr_cursor = self.buffer.ui:get_cursor_location()
+      pr_view = self.buffer:save_view()
+    end
+    self:redraw(pr_cursor, pr_view)
+  end)
+
   jj.repo:dispatch_refresh {
     source = "status",
     partial = partial,

--- a/lua/neojj/buffers/status/ui.lua
+++ b/lua/neojj/buffers/status/ui.lua
@@ -111,7 +111,7 @@ local ProjectHeader = Component.new(function(props)
   local project_name = vim.fn.fnamemodify(props.root, ":t")
   return row({
     text.highlight("NeojjSectionHeader")(project_name),
-  }, { yankable = "__project__" })
+  }, { kind = "project" })
 end)
 
 --- Head/Parent section showing current change and its parent
@@ -155,7 +155,13 @@ local JJHead = Component.new(function(props)
       text("  "),
       text(props.description ~= "" and vim.split(props.description, "\n")[1] or "(no description)"),
     },
-  }, { yankable = change_id, oid = change_id })
+  }, {
+    kind = "change",
+    yankable = change_id,
+    oid = change_id,
+    commit_id = commit_id,
+    bookmarks = props.bookmarks,
+  })
 end)
 
 local SectionTitle = Component.new(function(props)
@@ -276,6 +282,7 @@ local SectionItemFile = function(section, config)
       on_open = load_diff(item),
       context = true,
       id = ("%s--%s"):format(section, item.name),
+      kind = "file",
       yankable = item.name,
       filename = item.name,
       item = item,
@@ -304,6 +311,7 @@ local SectionItemChange = Component.new(function(item)
 
     local children = {
       row(parent_parts, {
+        kind = "change",
         yankable = item.change_id,
         oid = item.change_id,
         item = item,
@@ -354,6 +362,7 @@ local SectionItemChange = Component.new(function(item)
   table.insert(parts, text.highlight(status_highlight)(status_suffix))
 
   return row(parts, {
+    kind = "change",
     yankable = item.change_id,
     oid = item.change_id,
     item = item,
@@ -395,6 +404,7 @@ local SectionItemBookmark = Component.new(function(item)
   end
 
   return row(parts, {
+    kind = "bookmark",
     yankable = item.name,
     oid = (item.change_id and item.change_id ~= "") and item.change_id or nil,
     item = item,
@@ -406,6 +416,7 @@ local SectionItemConflict = Component.new(function(item)
     text.highlight("NeojjGraphRed")("C "),
     text(item.name),
   }, {
+    kind = "conflict",
     yankable = item.name,
     item = item,
   })

--- a/lua/neojj/buffers/status/ui.lua
+++ b/lua/neojj/buffers/status/ui.lua
@@ -17,6 +17,41 @@ local DiffHunks = common.DiffHunks
 
 local M = {}
 
+---PR annotation for a bookmark with a matching open PR on the forge.
+---@param bookmark string
+---@return table[]
+local function pr_annotation_parts(bookmark)
+  local forge = require("neojj.lib.forge")
+  local root = require("neojj.lib.jj").repo.state.worktree_root
+
+  local pr = forge.pr_for_branch(root, bookmark)
+  if not pr then
+    return {}
+  end
+
+  return { text(" "), text.highlight("NeojjForgePR")("#" .. pr.number) }
+end
+
+---Render bookmark labels for a change line, annotating local bookmarks that
+---have a matching open PR on the forge.
+---@param bookmarks string[]|nil
+---@param remote_bookmarks string[]|nil
+---@return table[]
+local function bookmark_parts(bookmarks, remote_bookmarks)
+  local parts = {}
+  for _, bm in ipairs(bookmarks or {}) do
+    table.insert(parts, text(" "))
+    table.insert(parts, text.highlight("NeojjBranchHead")(bm))
+    vim.list_extend(parts, pr_annotation_parts(bm))
+  end
+  for _, bm in ipairs(remote_bookmarks or {}) do
+    table.insert(parts, text(" "))
+    table.insert(parts, text.highlight("NeojjRemote")(bm))
+  end
+
+  return parts
+end
+
 local HINT = Component.new(function(props)
   ---@return table<string, string[]>
   local function reversed_lookup(tbl)
@@ -91,14 +126,6 @@ local JJHead = Component.new(function(props)
   local change_prefix = short_change:sub(1, prefix_len)
   local change_rest = short_change:sub(prefix_len + 1)
 
-  local bookmark_parts = {}
-  if props.bookmarks and #props.bookmarks > 0 then
-    for _, bm in ipairs(props.bookmarks) do
-      table.insert(bookmark_parts, text(" "))
-      table.insert(bookmark_parts, text.highlight("NeojjBranchHead")(bm))
-    end
-  end
-
   local status_parts = {}
   if props.empty then
     table.insert(status_parts, "empty")
@@ -116,7 +143,7 @@ local JJHead = Component.new(function(props)
     text(" "),
     text.highlight("NeojjObjectId")(short_commit),
   }
-  vim.list_extend(header_parts, bookmark_parts)
+  vim.list_extend(header_parts, bookmark_parts(props.bookmarks))
   table.insert(
     header_parts,
     text.highlight(props.conflict and "NeojjConflict" or "NeojjSubtleText")(status_text)
@@ -264,27 +291,13 @@ local SectionItemChange = Component.new(function(item)
     local change_prefix = change_id:sub(1, prefix_len)
     local change_rest = change_id:sub(prefix_len + 1)
 
-    local bookmark_parts = {}
-    if item.bookmarks and #item.bookmarks > 0 then
-      for _, bm in ipairs(item.bookmarks) do
-        table.insert(bookmark_parts, text(" "))
-        table.insert(bookmark_parts, text.highlight("NeojjBranchHead")(bm))
-      end
-    end
-    if item.remote_bookmarks and #item.remote_bookmarks > 0 then
-      for _, bm in ipairs(item.remote_bookmarks) do
-        table.insert(bookmark_parts, text(" "))
-        table.insert(bookmark_parts, text.highlight("NeojjRemote")(bm))
-      end
-    end
-
     local parent_parts = {
       text.highlight("NeojjChangeIdPrefix")(change_prefix),
       text.highlight("NeojjChangeIdRest")(change_rest),
       text(" "),
       text.highlight("NeojjDivergent")("<divergent>"),
     }
-    vim.list_extend(parent_parts, bookmark_parts)
+    vim.list_extend(parent_parts, bookmark_parts(item.bookmarks, item.remote_bookmarks))
     if item.immutable then
       table.insert(parent_parts, text.highlight("NeojjSubtleText")(" (immutable)"))
     end
@@ -312,20 +325,6 @@ local SectionItemChange = Component.new(function(item)
   local change_prefix = change_id:sub(1, prefix_len)
   local change_rest = change_id:sub(prefix_len + 1)
 
-  local bookmark_parts = {}
-  if item.bookmarks and #item.bookmarks > 0 then
-    for _, bm in ipairs(item.bookmarks) do
-      table.insert(bookmark_parts, text(" "))
-      table.insert(bookmark_parts, text.highlight("NeojjBranchHead")(bm))
-    end
-  end
-  if item.remote_bookmarks and #item.remote_bookmarks > 0 then
-    for _, bm in ipairs(item.remote_bookmarks) do
-      table.insert(bookmark_parts, text(" "))
-      table.insert(bookmark_parts, text.highlight("NeojjRemote")(bm))
-    end
-  end
-
   local status_parts = {}
   if item.immutable then
     table.insert(status_parts, "immutable")
@@ -349,7 +348,7 @@ local SectionItemChange = Component.new(function(item)
     text(" "),
     text.highlight("NeojjObjectId")(commit_id),
   }
-  vim.list_extend(parts, bookmark_parts)
+  vim.list_extend(parts, bookmark_parts(item.bookmarks, item.remote_bookmarks))
   table.insert(parts, text(" "))
   table.insert(parts, text(item.description and vim.split(item.description, "\n")[1] or "(no description)"))
   table.insert(parts, text.highlight(status_highlight)(status_suffix))
@@ -379,6 +378,10 @@ local SectionItemBookmark = Component.new(function(item)
   local parts = {
     text.highlight(highlight)(label),
   }
+
+  if not item.deleted and (not item.remote or item.remote == "") then
+    vim.list_extend(parts, pr_annotation_parts(item.name))
+  end
 
   if item.deleted then
     table.insert(parts, text.highlight("NeojjSubtleText")(" (deleted)"))

--- a/lua/neojj/config.lua
+++ b/lua/neojj/config.lua
@@ -109,6 +109,10 @@ end
 ---@field spell_check? boolean Enable/Disable spell checking
 ---@field describe_editor? boolean Use full editor for `dd` describe action (false = inline input)
 
+---@class NeojjForgeConfig
+---@field pr_integration boolean Match bookmarks to open PRs and let "o" open them in the browser
+---@field hosts table<string, string[]> Extra remote hosts per provider name, e.g. { github = { "git.corp.com" } }
+
 ---@alias NeojjConfigSignsIcon { [1]: string, [2]: string }
 
 ---@class NeojjConfigSigns
@@ -309,6 +313,7 @@ end
 ---@field popup? NeojjConfigPopup Set the default way of opening popups
 ---@field signs? NeojjConfigSigns Signs used for toggled regions
 ---@field integrations? { diffview: boolean, codediff: boolean, telescope: boolean, fzf_lua: boolean, mini_pick: boolean, snacks: boolean } Which integrations to enable
+---@field forge? NeojjForgeConfig Forge (GitHub, ...) integration options
 ---@field diff_viewer? "diffview"|"codediff"|nil Which diff viewer to use (nil = auto-detect)
 ---@field sections? NeojjConfigSections
 ---@field ignored_settings? string[] Settings to never persist, format: "Filetype--cli-value", i.e. "NeojjCommitPopup--author"
@@ -432,6 +437,10 @@ function M.get_default_values()
       fzf_lua = nil,
       mini_pick = nil,
       snacks = nil,
+    },
+    forge = {
+      pr_integration = true,
+      hosts = {},
     },
     diff_viewer = nil,
     sections = {
@@ -714,6 +723,25 @@ function M.validate_config()
             table.concat(valid_integrations, ", ")
           )
         )
+      end
+    end
+  end
+
+  local function validate_forge()
+    if not validate_type(config.forge, "forge", "table") then
+      return
+    end
+
+    validate_type(config.forge.pr_integration, "forge.pr_integration", "boolean")
+
+    if validate_type(config.forge.hosts, "forge.hosts", "table") then
+      for provider_name, hosts in pairs(config.forge.hosts) do
+        local name = string.format("forge.hosts.%s", provider_name)
+        if validate_type(hosts, name, "table") then
+          for i, host in ipairs(hosts) do
+            validate_type(host, string.format("%s[%d]", name, i), "string")
+          end
+        end
       end
     end
   end
@@ -1031,6 +1059,7 @@ function M.validate_config()
 
     validate_integrations()
     validate_diff_viewer()
+    validate_forge()
     validate_sections()
     validate_ignored_settings()
     validate_mappings()

--- a/lua/neojj/lib/forge/github.lua
+++ b/lua/neojj/lib/forge/github.lua
@@ -1,0 +1,51 @@
+---GitHub forge provider, backed by the `gh` CLI.
+---@type neojj.Forge
+local M = {
+  name = "github",
+  executable = "gh",
+  default_hosts = { "github.com" },
+  pr_list_cmd = {
+    "gh",
+    "pr",
+    "list",
+    "--state",
+    "open",
+    "--limit",
+    "200",
+    "--json",
+    "number,title,url,headRefName,isCrossRepository,isDraft",
+  },
+
+  ---Parse `gh pr list --json` output into normalized PRs. Cross-repository
+  ---(fork) PRs are dropped: their head ref names live in the fork's namespace
+  ---and would falsely match local bookmarks.
+  ---@param stdout string|nil
+  ---@return neojj.ForgePR[]|nil
+  parse_prs = function(stdout)
+    if type(stdout) ~= "string" then
+      return nil
+    end
+
+    local ok, decoded = pcall(vim.json.decode, stdout)
+    if not ok or type(decoded) ~= "table" then
+      return nil
+    end
+
+    local prs = {}
+    for _, raw in ipairs(decoded) do
+      if not raw.isCrossRepository then
+        table.insert(prs, {
+          number = raw.number,
+          title = raw.title,
+          url = raw.url,
+          branch = raw.headRefName,
+          draft = raw.isDraft == true,
+        })
+      end
+    end
+
+    return prs
+  end,
+}
+
+return M

--- a/lua/neojj/lib/forge/init.lua
+++ b/lua/neojj/lib/forge/init.lua
@@ -1,0 +1,149 @@
+---Forge integration: matches local bookmarks to open PRs on a remote
+---forge (GitHub today; other providers slot into the registry below).
+---
+---A provider supplies its identity and CLI; everything else — host
+---resolution, gating, the async fetch, and the per-root cache — lives here
+---and is provider-agnostic.
+
+---@class neojj.ForgePR
+---@field number integer
+---@field title string
+---@field url string
+---@field branch string Head ref name, matched against bookmark names
+---@field draft boolean
+
+---@class neojj.Forge
+---@field name string
+---@field executable string CLI binary the provider shells out to
+---@field default_hosts string[]
+---@field pr_list_cmd string[] Command listing open PRs as JSON on stdout
+---@field parse_prs fun(stdout: string|nil): neojj.ForgePR[]|nil
+
+local logger = require("neojj.logger")
+
+local M = {}
+
+---@type neojj.Forge[]
+local providers = {
+  require("neojj.lib.forge.github"),
+}
+
+---@class neojj.ForgeCacheEntry
+---@field index table<string, neojj.ForgePR>|nil
+---@field failed boolean|nil Fetch failed once; don't retry this session
+---@field in_flight boolean|nil
+
+---@type table<string, neojj.ForgeCacheEntry>
+local cache = {}
+
+---Resolve the provider responsible for a remote host.
+---@param host string|nil
+---@param extra_hosts table<string, string[]>|nil Additional hosts per provider name (e.g. GitHub Enterprise)
+---@return neojj.Forge|nil
+function M.provider_for_host(host, extra_hosts)
+  if not host then
+    return nil
+  end
+
+  for _, provider in ipairs(providers) do
+    local hosts = vim.deepcopy(provider.default_hosts)
+    vim.list_extend(hosts, extra_hosts and extra_hosts[provider.name] or {})
+    if vim.tbl_contains(hosts, host) then
+      return provider
+    end
+  end
+
+  return nil
+end
+
+---Index PRs by head branch name; first PR wins on collision.
+---@param prs neojj.ForgePR[]
+---@return table<string, neojj.ForgePR>
+function M.build_index(prs)
+  local index = {}
+  for _, pr in ipairs(prs) do
+    if index[pr.branch] == nil then
+      index[pr.branch] = pr
+    end
+  end
+
+  return index
+end
+
+---@param root string
+---@param branch string|nil
+---@return neojj.ForgePR|nil
+function M.pr_for_branch(root, branch)
+  local entry = cache[root]
+  if not (entry and entry.index and branch) then
+    return nil
+  end
+
+  return entry.index[branch]
+end
+
+---@param root string|nil Reset one root, or all when nil
+function M.reset(root)
+  if root then
+    cache[root] = nil
+  else
+    cache = {}
+  end
+end
+
+---Test seam: install a prebuilt index for a root.
+---@param root string
+---@param index table<string, neojj.ForgePR>
+function M._set_index(root, index)
+  cache[root] = { index = index }
+end
+
+---Fetch open PRs for a worktree root if the integration is enabled, the
+---provider CLI is installed, and the remote host matches a provider.
+---Failures are silent and remembered: this never retries within a session,
+---and `callback` runs (on the main loop) only when fresh data arrives.
+---@param root string
+---@param callback fun()|nil
+function M.refresh(root, callback)
+  local forge_config = require("neojj.config").values.forge
+  if not (forge_config and forge_config.pr_integration) then
+    return
+  end
+
+  local entry = cache[root]
+  if entry and (entry.failed or entry.in_flight) then
+    return
+  end
+
+  local info = require("neojj.lib.jj.remote").get(root)
+  local provider = info and M.provider_for_host(info.host, forge_config.hosts)
+  if not provider or vim.fn.executable(provider.executable) ~= 1 then
+    cache[root] = { failed = true }
+    return
+  end
+
+  cache[root] = { in_flight = true, index = entry and entry.index }
+  vim.system(provider.pr_list_cmd, { cwd = root, text = true }, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        logger.debug("[FORGE] " .. provider.name .. " pr list failed: " .. (result.stderr or ""))
+        cache[root] = { failed = true }
+        return
+      end
+
+      local prs = provider.parse_prs(result.stdout)
+      if not prs then
+        logger.debug("[FORGE] " .. provider.name .. " pr list output unparsable")
+        cache[root] = { failed = true }
+        return
+      end
+
+      cache[root] = { index = M.build_index(prs) }
+      if callback then
+        callback()
+      end
+    end)
+  end)
+end
+
+return M

--- a/lua/neojj/lib/forge/init.lua
+++ b/lua/neojj/lib/forge/init.lua
@@ -30,11 +30,15 @@ local providers = {
 
 ---@class neojj.ForgeCacheEntry
 ---@field index table<string, neojj.ForgePR>|nil
+---@field fetched_at number|nil Monotonic ms timestamp of the last successful fetch
 ---@field failed boolean|nil Fetch failed once; don't retry this session
 ---@field in_flight boolean|nil
 
 ---@type table<string, neojj.ForgeCacheEntry>
 local cache = {}
+
+---Successful fetches are reused for this long; a manual refresh busts it.
+local TTL_MS = 30000
 
 ---Resolve the provider responsible for a remote host.
 ---@param host string|nil
@@ -102,24 +106,66 @@ function M._set_index(root, index)
   cache[root] = { index = index }
 end
 
+---Whether a fetch should be spawned given the cache entry's state.
+---@param entry neojj.ForgeCacheEntry|nil
+---@param now number Monotonic ms timestamp
+---@param force boolean|nil Bypass the TTL (manual refresh)
+---@return boolean
+function M.should_fetch(entry, now, force)
+  if not entry then
+    return true
+  end
+  if entry.failed or entry.in_flight then
+    return false
+  end
+  if force or not entry.fetched_at then
+    return true
+  end
+
+  return (now - entry.fetched_at) > TTL_MS
+end
+
+---Store fetched PRs for a root and report whether the data changed,
+---so callers can skip redrawing when nothing did.
+---@param root string
+---@param prs neojj.ForgePR[]
+---@param now number Monotonic ms timestamp
+---@return boolean changed
+function M._apply_result(root, prs, now)
+  local old_index = cache[root] and cache[root].index
+  local index = M.build_index(prs)
+  cache[root] = { index = index, fetched_at = now }
+
+  return not vim.deep_equal(old_index, index)
+end
+
 ---Fetch open PRs for a worktree root if the integration is enabled, the
 ---provider CLI is installed, and the remote host matches a provider.
----Failures are silent and remembered: this never retries within a session,
----and `callback` runs (on the main loop) only when fresh data arrives.
+---Successful results are cached for TTL_MS; opts.force (manual refresh)
+---busts the cache. Failures are silent and remembered: this never retries
+---within a session, and `callback` runs (on the main loop) only when the
+---PR data actually changed.
 ---@param root string
+---@param opts { force: boolean|nil }|nil
 ---@param callback fun()|nil
-function M.refresh(root, callback)
+function M.refresh(root, opts, callback)
   local forge_config = require("neojj.config").values.forge
   if not (forge_config and forge_config.pr_integration) then
     return
   end
 
+  local force = opts and opts.force or false
   local entry = cache[root]
-  if entry and (entry.failed or entry.in_flight) then
+  if not M.should_fetch(entry, vim.uv.now(), force) then
     return
   end
 
-  local info = require("neojj.lib.jj.remote").get(root)
+  local remote = require("neojj.lib.jj.remote")
+  if force then
+    remote.invalidate(root)
+  end
+
+  local info = remote.get(root)
   local provider = info and M.provider_for_host(info.host, forge_config.hosts)
   if not provider or vim.fn.executable(provider.executable) ~= 1 then
     cache[root] = { failed = true }
@@ -142,8 +188,8 @@ function M.refresh(root, callback)
         return
       end
 
-      cache[root] = { index = M.build_index(prs) }
-      if callback then
+      local changed = M._apply_result(root, prs, vim.uv.now())
+      if changed and callback then
         callback()
       end
     end)

--- a/lua/neojj/lib/forge/init.lua
+++ b/lua/neojj/lib/forge/init.lua
@@ -70,11 +70,15 @@ function M.build_index(prs)
   return index
 end
 
+---Look up the open PR for a bookmark. The name may carry jj display
+---decorations (`name*`, `name??`, `name@origin`); matching is on the bare
+---branch name.
 ---@param root string
----@param branch string|nil
+---@param bookmark string|nil
 ---@return neojj.ForgePR|nil
-function M.pr_for_branch(root, branch)
+function M.pr_for_branch(root, bookmark)
   local entry = cache[root]
+  local branch = require("neojj.lib.jj.bookmark").normalize(bookmark)
   if not (entry and entry.index and branch) then
     return nil
   end

--- a/lua/neojj/lib/forge/init.lua
+++ b/lua/neojj/lib/forge/init.lua
@@ -160,12 +160,7 @@ function M.refresh(root, opts, callback)
     return
   end
 
-  local remote = require("neojj.lib.jj.remote")
-  if force then
-    remote.invalidate(root)
-  end
-
-  local info = remote.get(root)
+  local info = require("neojj.lib.jj.remote").get(root)
   local provider = info and M.provider_for_host(info.host, forge_config.hosts)
   if not provider or vim.fn.executable(provider.executable) ~= 1 then
     cache[root] = { failed = true }

--- a/lua/neojj/lib/hl.lua
+++ b/lua/neojj/lib/hl.lua
@@ -226,6 +226,7 @@ function M.setup(config)
     NeojjBranch                   = { fg = palette.blue, bold = palette.bold, ctermfg = 4 },
     NeojjBranchHead               = { fg = palette.blue, bold = palette.bold, underline = palette.underline, ctermfg = 4 },
     NeojjRemote                   = { fg = palette.green, bold = palette.bold, ctermfg = 2 },
+    NeojjForgePR                  = { fg = palette.purple, bold = palette.bold, ctermfg = 5 },
     NeojjObjectId                 = { fg = palette.bg_cyan, ctermfg = 7 },
     NeojjChangeId                 = { fg = palette.bg_purple, ctermfg = 6 },
     NeojjChangeIdPrefix           = { fg = palette.purple, bold = palette.bold, ctermfg = 5 },

--- a/lua/neojj/lib/jj/bookmark.lua
+++ b/lua/neojj/lib/jj/bookmark.lua
@@ -16,6 +16,21 @@ local M = {}
 ---@class NeojjBookmarkMeta
 local meta = {}
 
+---Strip jj display decorations from a bookmark name: the unpushed marker
+---(`name*`), conflict markers (`name??`), and a remote qualifier
+---(`name@origin`). Git ref names cannot contain `*`, `?`, or `@`-qualifiers,
+---so the leading run of other characters is the bare name.
+---@param name string|nil
+---@return string|nil
+function M.normalize(name)
+  if type(name) ~= "string" then
+    return nil
+  end
+
+  local bare = name:match("^([^@*?]+)")
+  return bare
+end
+
 ---Parse `jj bookmark list --all` output
 ---Local format: "name: change_id commit_id [| ] description"
 ---Local deleted: "name (deleted)"

--- a/lua/neojj/lib/jj/remote.lua
+++ b/lua/neojj/lib/jj/remote.lua
@@ -4,9 +4,6 @@
 
 local M = {}
 
----@type table<string, neojj.RemoteInfo|false>
-local cache = {}
-
 ---Normalize a git remote URL into its host and https browser URL.
 ---@param url string|nil
 ---@return neojj.RemoteInfo|nil
@@ -26,39 +23,25 @@ function M.parse(url)
   return { host = host, browser_url = https }
 end
 
----Resolve the first git remote for a worktree root, cached per root.
+---Resolve the first git remote for a worktree root.
 ---@param root string
 ---@return neojj.RemoteInfo|nil
 function M.get(root)
-  if cache[root] ~= nil then
-    return cache[root] or nil
-  end
-
   local shell = require("neojj.lib.jj.shell")
   local lines, code = shell.exec({ "jj", "--no-pager", "--color=never", "git", "remote", "list" }, root)
 
-  local info
-  if code == 0 and lines then
-    for _, line in ipairs(lines) do
-      local url = line:match("^%S+%s+(%S+)")
-      if url then
-        info = M.parse(url)
-        break
-      end
+  if code ~= 0 or not lines then
+    return nil
+  end
+
+  for _, line in ipairs(lines) do
+    local url = line:match("^%S+%s+(%S+)")
+    if url then
+      return M.parse(url)
     end
   end
 
-  cache[root] = info or false
-  return info
-end
-
----@param root string|nil Invalidate one root, or all when nil
-function M.invalidate(root)
-  if root then
-    cache[root] = nil
-  else
-    cache = {}
-  end
+  return nil
 end
 
 return M

--- a/lua/neojj/lib/jj/remote.lua
+++ b/lua/neojj/lib/jj/remote.lua
@@ -1,0 +1,64 @@
+---@class neojj.RemoteInfo
+---@field host string
+---@field browser_url string
+
+local M = {}
+
+---@type table<string, neojj.RemoteInfo|false>
+local cache = {}
+
+---Normalize a git remote URL into its host and https browser URL.
+---@param url string|nil
+---@return neojj.RemoteInfo|nil
+function M.parse(url)
+  if type(url) ~= "string" then
+    return nil
+  end
+
+  local https =
+    url:gsub("%.git$", ""):gsub("^git@([^:]+):", "https://%1/"):gsub("^ssh://git@([^/]+)/", "https://%1/")
+
+  local host = https:match("^https?://([^/]+)/.")
+  if not host then
+    return nil
+  end
+
+  return { host = host, browser_url = https }
+end
+
+---Resolve the first git remote for a worktree root, cached per root.
+---@param root string
+---@return neojj.RemoteInfo|nil
+function M.get(root)
+  if cache[root] ~= nil then
+    return cache[root] or nil
+  end
+
+  local shell = require("neojj.lib.jj.shell")
+  local lines, code = shell.exec({ "jj", "--no-pager", "--color=never", "git", "remote", "list" }, root)
+
+  local info
+  if code == 0 and lines then
+    for _, line in ipairs(lines) do
+      local url = line:match("^%S+%s+(%S+)")
+      if url then
+        info = M.parse(url)
+        break
+      end
+    end
+  end
+
+  cache[root] = info or false
+  return info
+end
+
+---@param root string|nil Invalidate one root, or all when nil
+function M.invalidate(root)
+  if root then
+    cache[root] = nil
+  else
+    cache = {}
+  end
+end
+
+return M

--- a/lua/neojj/lib/ui/component.lua
+++ b/lua/neojj/lib/ui/component.lua
@@ -11,26 +11,31 @@ local default_component_options = {
 ---@field col_start integer
 ---@field col_end integer
 
+---Every field is optional: components declare only the options relevant to
+---their line, and defaults are merged in at construction time.
 ---@class ComponentOptions
----@field line_hl string
----@field highlight string
+---@field line_hl string|nil
+---@field highlight string|nil
 ---@field align_right integer|nil
----@field padding_left integer
----@field tag string
----@field foldable boolean
----@field folded boolean
----@field context boolean
----@field interactive boolean
----@field virtual_text string
+---@field padding_left integer|nil
+---@field tag string|nil
+---@field foldable boolean|nil
+---@field folded boolean|nil
+---@field context boolean|nil
+---@field interactive boolean|nil
+---@field virtual_text string|nil
 ---@field section string|nil
 ---@field item table|nil
 ---@field id string|nil
 ---@field oid string|nil
----@field ref ParsedRef
----@field yankable string?
----@field on_open fun(fold, Ui)
----@field hunk Hunk
----@field filename string?
+---@field ref ParsedRef|nil
+---@field yankable string|nil
+---@field kind UiContextKind|nil Semantic kind of the line, resolved by Ui.resolve_context
+---@field bookmarks string[]|nil Bookmark names on lines without an item (head/parent headers)
+---@field commit_id string|nil Commit id on lines without an item (head/parent headers)
+---@field on_open fun(fold, Ui)|nil
+---@field hunk Hunk|nil
+---@field filename string|nil
 ---@field value any
 
 ---@class Component

--- a/lua/neojj/lib/ui/init.lua
+++ b/lua/neojj/lib/ui/init.lua
@@ -164,6 +164,74 @@ function Ui:get_cursor_context(line)
   end)
 end
 
+---@alias UiContextKind "change"|"file"|"bookmark"|"conflict"|"project"
+
+---@class UiContext
+---@field kind UiContextKind
+---@field item StatusItem|nil
+---@field oid string|nil
+---@field yank string|nil
+---@field change_id string|nil
+---@field commit_id string|nil
+---@field bookmarks string[] Bookmark names rendered on the line
+
+---Resolve a context node's options into a UiContext. Pure: this is the one
+---place that knows how each line kind exposes its change_id and bookmarks,
+---so consumers branch on `kind` instead of duck-typing items or matching
+---section names.
+---@param options ComponentOptions|nil Component options of the nearest node with a `kind`
+---@return UiContext|nil
+function Ui.resolve_context(options)
+  if not options or not options.kind then
+    return nil
+  end
+
+  local ctx = {
+    kind = options.kind,
+    item = options.item,
+    oid = options.oid,
+    yank = options.yankable,
+    bookmarks = {},
+  }
+
+  if options.item and options.item.change_id and options.item.change_id ~= "" then
+    ctx.change_id = options.item.change_id
+  elseif options.kind == "change" then
+    -- Change lines set oid to their change_id (variant rows set a commit_id,
+    -- but those always carry an item, handled above).
+    ctx.change_id = options.oid
+  end
+
+  if options.item and options.item.commit_id and options.item.commit_id ~= "" then
+    ctx.commit_id = options.item.commit_id
+  else
+    -- Head/parent header lines carry no item; they set commit_id directly
+    ctx.commit_id = options.commit_id
+  end
+
+  if options.kind == "bookmark" and options.item and options.item.name then
+    ctx.bookmarks = { options.item.name }
+  elseif options.bookmarks then
+    ctx.bookmarks = options.bookmarks
+  elseif options.item and options.item.bookmarks then
+    ctx.bookmarks = options.item.bookmarks
+  end
+
+  return ctx
+end
+
+---The semantic context of the line under the cursor: nearest ancestor
+---component tagged with a `kind`, resolved into a UiContext.
+---@return UiContext|nil
+function Ui:context_under_cursor()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local node = self:_find_component_by_index(cursor[1], function(n)
+    return n.options.kind ~= nil
+  end)
+
+  return node and Ui.resolve_context(node.options) or nil
+end
+
 ---@return string|nil
 function Ui:get_line_highlight(line)
   local component = self:_find_component_by_index(line, function(node)

--- a/tests/specs/neojj/config_spec.lua
+++ b/tests/specs/neojj/config_spec.lua
@@ -470,10 +470,39 @@ describe("NeoJJ config", function()
           assert.True(vim.tbl_count(require("neojj.config").validate_config()) ~= 0)
         end)
       end)
+
+      describe("forge", function()
+        it("should return invalid when forge isn't a table", function()
+          config.values.forge = "not a table"
+          assert.True(vim.tbl_count(require("neojj.config").validate_config()) ~= 0)
+        end)
+
+        it("should return invalid when forge.pr_integration isn't a boolean", function()
+          config.values.forge.pr_integration = "not a boolean"
+          assert.True(vim.tbl_count(require("neojj.config").validate_config()) ~= 0)
+        end)
+
+        it("should return invalid when forge.hosts isn't a table of string lists", function()
+          config.values.forge.hosts = "not a table"
+          assert.True(vim.tbl_count(require("neojj.config").validate_config()) ~= 0)
+
+          config.values = config.get_default_values()
+          config.values.forge.hosts = { github = "not a list" }
+          assert.True(vim.tbl_count(require("neojj.config").validate_config()) ~= 0)
+        end)
+      end)
     end)
 
     describe("for good configs", function()
       it("should return valid for the default config", function()
+        assert.True(vim.tbl_count(require("neojj.config").validate_config()) == 0)
+      end)
+
+      it("should return valid for a forge config with extra hosts", function()
+        config.values.forge = {
+          pr_integration = false,
+          hosts = { github = { "git.corp.com" } },
+        }
         assert.True(vim.tbl_count(require("neojj.config").validate_config()) == 0)
       end)
 

--- a/tests/specs/neojj/lib/forge/github_spec.lua
+++ b/tests/specs/neojj/lib/forge/github_spec.lua
@@ -1,0 +1,71 @@
+local github = require("neojj.lib.forge.github")
+
+describe("forge.github", function()
+  it("declares its identity", function()
+    assert.are.equal("github", github.name)
+    assert.are.equal("gh", github.executable)
+    assert.are.same({ "github.com" }, github.default_hosts)
+  end)
+
+  describe("parse_prs", function()
+    it("maps gh json output to normalized PRs", function()
+      local stdout = vim.json.encode {
+        {
+          number = 22,
+          title = "feat: add tracking",
+          url = "https://github.com/User/repo/pull/22",
+          headRefName = "my-feature",
+          isCrossRepository = false,
+          isDraft = false,
+        },
+      }
+      local prs = github.parse_prs(stdout)
+      assert.are.same({
+        {
+          number = 22,
+          title = "feat: add tracking",
+          url = "https://github.com/User/repo/pull/22",
+          branch = "my-feature",
+          draft = false,
+        },
+      }, prs)
+    end)
+
+    it("filters out cross-repository (fork) PRs", function()
+      local stdout = vim.json.encode {
+        {
+          number = 5,
+          title = "fork pr",
+          url = "https://github.com/User/repo/pull/5",
+          headRefName = "main",
+          isCrossRepository = true,
+          isDraft = false,
+        },
+        {
+          number = 6,
+          title = "own pr",
+          url = "https://github.com/User/repo/pull/6",
+          headRefName = "fix-thing",
+          isCrossRepository = false,
+          isDraft = true,
+        },
+      }
+      local prs = github.parse_prs(stdout)
+      assert.are.equal(1, #prs)
+      assert.are.equal(6, prs[1].number)
+      assert.True(prs[1].draft)
+    end)
+
+    it("returns an empty list for no PRs", function()
+      assert.are.same({}, github.parse_prs("[]"))
+    end)
+
+    it("returns nil for invalid json", function()
+      assert.is_nil(github.parse_prs("gh: not logged in"))
+    end)
+
+    it("returns nil for nil input", function()
+      assert.is_nil(github.parse_prs(nil))
+    end)
+  end)
+end)

--- a/tests/specs/neojj/lib/forge/init_spec.lua
+++ b/tests/specs/neojj/lib/forge/init_spec.lua
@@ -1,0 +1,69 @@
+local forge = require("neojj.lib.forge")
+
+describe("forge", function()
+  describe("provider_for_host", function()
+    it("resolves github.com to the github provider", function()
+      local provider = forge.provider_for_host("github.com")
+      assert.is_not_nil(provider)
+      assert.are.equal("github", provider.name)
+    end)
+
+    it("returns nil for unknown hosts", function()
+      assert.is_nil(forge.provider_for_host("gitlab.com"))
+      assert.is_nil(forge.provider_for_host("git.corp.com"))
+    end)
+
+    it("returns nil for nil host", function()
+      assert.is_nil(forge.provider_for_host(nil))
+    end)
+
+    it("matches extra hosts configured per provider", function()
+      local provider = forge.provider_for_host("git.corp.com", { github = { "git.corp.com" } })
+      assert.is_not_nil(provider)
+      assert.are.equal("github", provider.name)
+    end)
+
+    it("still matches default hosts when extra hosts are configured", function()
+      local provider = forge.provider_for_host("github.com", { github = { "git.corp.com" } })
+      assert.is_not_nil(provider)
+      assert.are.equal("github", provider.name)
+    end)
+  end)
+
+  describe("build_index", function()
+    it("indexes PRs by branch name", function()
+      local pr = { number = 22, title = "t", url = "u", branch = "my-feature", draft = false }
+      local index = forge.build_index { pr }
+      assert.are.equal(pr, index["my-feature"])
+      assert.is_nil(index["other"])
+    end)
+
+    it("keeps the first PR when branches collide", function()
+      local first = { number = 1, title = "a", url = "u1", branch = "dup", draft = false }
+      local second = { number = 2, title = "b", url = "u2", branch = "dup", draft = false }
+      local index = forge.build_index { first, second }
+      assert.are.equal(first, index["dup"])
+    end)
+
+    it("returns an empty index for no PRs", function()
+      assert.are.same({}, forge.build_index {})
+    end)
+  end)
+
+  describe("pr_for_branch", function()
+    before_each(function()
+      forge.reset()
+    end)
+
+    it("returns nil when nothing is cached", function()
+      assert.is_nil(forge.pr_for_branch("/some/root", "my-feature"))
+    end)
+
+    it("returns the cached PR after a successful fetch", function()
+      local pr = { number = 22, title = "t", url = "u", branch = "my-feature", draft = false }
+      forge._set_index("/some/root", forge.build_index { pr })
+      assert.are.equal(pr, forge.pr_for_branch("/some/root", "my-feature"))
+      assert.is_nil(forge.pr_for_branch("/other/root", "my-feature"))
+    end)
+  end)
+end)

--- a/tests/specs/neojj/lib/forge/init_spec.lua
+++ b/tests/specs/neojj/lib/forge/init_spec.lua
@@ -65,5 +65,13 @@ describe("forge", function()
       assert.are.equal(pr, forge.pr_for_branch("/some/root", "my-feature"))
       assert.is_nil(forge.pr_for_branch("/other/root", "my-feature"))
     end)
+
+    it("matches bookmark names carrying jj status decorations", function()
+      local pr = { number = 22, title = "t", url = "u", branch = "my-feature", draft = false }
+      forge._set_index("/some/root", forge.build_index { pr })
+      assert.are.equal(pr, forge.pr_for_branch("/some/root", "my-feature*"))
+      assert.are.equal(pr, forge.pr_for_branch("/some/root", "my-feature??"))
+      assert.are.equal(pr, forge.pr_for_branch("/some/root", "my-feature@origin"))
+    end)
   end)
 end)

--- a/tests/specs/neojj/lib/forge/init_spec.lua
+++ b/tests/specs/neojj/lib/forge/init_spec.lua
@@ -74,4 +74,58 @@ describe("forge", function()
       assert.are.equal(pr, forge.pr_for_branch("/some/root", "my-feature@origin"))
     end)
   end)
+
+  describe("should_fetch", function()
+    it("fetches when nothing is cached", function()
+      assert.is_true(forge.should_fetch(nil, 1000, false))
+    end)
+
+    it("never fetches after a failure or while in flight", function()
+      assert.is_false(forge.should_fetch({ failed = true }, 1000, false))
+      assert.is_false(forge.should_fetch({ failed = true }, 1000, true))
+      assert.is_false(forge.should_fetch({ in_flight = true }, 1000, false))
+    end)
+
+    it("skips fetching within the TTL", function()
+      local entry = { index = {}, fetched_at = 1000 }
+      assert.is_false(forge.should_fetch(entry, 1000 + 29000, false))
+    end)
+
+    it("fetches again once the TTL has expired", function()
+      local entry = { index = {}, fetched_at = 1000 }
+      assert.is_true(forge.should_fetch(entry, 1000 + 31000, false))
+    end)
+
+    it("force bypasses the TTL but not failure", function()
+      local entry = { index = {}, fetched_at = 1000 }
+      assert.is_true(forge.should_fetch(entry, 1000 + 1, true))
+    end)
+  end)
+
+  describe("_apply_result", function()
+    before_each(function()
+      forge.reset()
+    end)
+
+    it("reports changed on first data", function()
+      local pr = { number = 22, title = "t", url = "u", branch = "b", draft = false }
+      assert.is_true(forge._apply_result("/root", { pr }, 1000))
+      assert.are.equal(22, forge.pr_for_branch("/root", "b").number)
+    end)
+
+    it("reports unchanged when the same PRs arrive again", function()
+      local pr = { number = 22, title = "t", url = "u", branch = "b", draft = false }
+      forge._apply_result("/root", { pr }, 1000)
+      assert.is_false(forge._apply_result("/root", { pr }, 2000))
+    end)
+
+    it("reports changed when a PR appears, changes, or disappears", function()
+      local pr = { number = 22, title = "t", url = "u", branch = "b", draft = false }
+      forge._apply_result("/root", { pr }, 1000)
+      local retitled = { number = 22, title = "new", url = "u", branch = "b", draft = false }
+      assert.is_true(forge._apply_result("/root", { retitled }, 2000))
+      assert.is_true(forge._apply_result("/root", {}, 3000))
+      assert.is_nil(forge.pr_for_branch("/root", "b"))
+    end)
+  end)
 end)

--- a/tests/specs/neojj/lib/jj/bookmark_spec.lua
+++ b/tests/specs/neojj/lib/jj/bookmark_spec.lua
@@ -101,4 +101,28 @@ describe("jj bookmark parser", function()
       assert.are.equal(2, #items)
     end)
   end)
+
+  describe("normalize", function()
+    it("returns a plain name unchanged", function()
+      assert.are.equal("main", bookmark.normalize("main"))
+      assert.are.equal("nicholas/forge-pr", bookmark.normalize("nicholas/forge-pr"))
+    end)
+
+    it("strips the unpushed decoration", function()
+      assert.are.equal("main", bookmark.normalize("main*"))
+    end)
+
+    it("strips the conflict decoration", function()
+      assert.are.equal("main", bookmark.normalize("main??"))
+    end)
+
+    it("strips a remote qualifier", function()
+      assert.are.equal("main", bookmark.normalize("main@origin"))
+    end)
+
+    it("returns nil for nil or undecorated-empty input", function()
+      assert.is_nil(bookmark.normalize(nil))
+      assert.is_nil(bookmark.normalize(""))
+    end)
+  end)
 end)

--- a/tests/specs/neojj/lib/jj/remote_spec.lua
+++ b/tests/specs/neojj/lib/jj/remote_spec.lua
@@ -1,0 +1,36 @@
+local remote = require("neojj.lib.jj.remote")
+
+describe("remote.parse", function()
+  it("parses an scp-style ssh remote", function()
+    local info = remote.parse("git@github.com:User/repo.git")
+    assert.are.same({ host = "github.com", browser_url = "https://github.com/User/repo" }, info)
+  end)
+
+  it("parses an ssh:// remote", function()
+    local info = remote.parse("ssh://git@github.com/User/repo.git")
+    assert.are.same({ host = "github.com", browser_url = "https://github.com/User/repo" }, info)
+  end)
+
+  it("parses an https remote", function()
+    local info = remote.parse("https://github.com/User/repo.git")
+    assert.are.same({ host = "github.com", browser_url = "https://github.com/User/repo" }, info)
+  end)
+
+  it("parses an https remote without .git suffix", function()
+    local info = remote.parse("https://gitlab.com/group/project")
+    assert.are.same({ host = "gitlab.com", browser_url = "https://gitlab.com/group/project" }, info)
+  end)
+
+  it("parses a self-hosted ssh remote", function()
+    local info = remote.parse("git@git.corp.com:team/repo.git")
+    assert.are.same({ host = "git.corp.com", browser_url = "https://git.corp.com/team/repo" }, info)
+  end)
+
+  it("returns nil for an unparsable url", function()
+    assert.is_nil(remote.parse("not a url"))
+  end)
+
+  it("returns nil for nil input", function()
+    assert.is_nil(remote.parse(nil))
+  end)
+end)

--- a/tests/specs/neojj/lib/ui/context_spec.lua
+++ b/tests/specs/neojj/lib/ui/context_spec.lua
@@ -1,0 +1,59 @@
+local Ui = require("neojj.lib.ui")
+
+describe("Ui.resolve_context", function()
+  it("returns nil when options carry no kind", function()
+    assert.is_nil(Ui.resolve_context(nil))
+    assert.is_nil(Ui.resolve_context {})
+    assert.is_nil(Ui.resolve_context { oid = "abc", yankable = "abc" })
+  end)
+
+  it("resolves a project header", function()
+    local ctx = Ui.resolve_context { kind = "project" }
+    assert.are.equal("project", ctx.kind)
+    assert.is_nil(ctx.change_id)
+    assert.are.same({}, ctx.bookmarks)
+  end)
+
+  it("resolves a bookmark line to its own name", function()
+    local item = { name = "my-feature", change_id = "abcdef12" }
+    local ctx = Ui.resolve_context { kind = "bookmark", item = item }
+    assert.are.equal("bookmark", ctx.kind)
+    assert.are.same({ "my-feature" }, ctx.bookmarks)
+    assert.are.equal("abcdef12", ctx.change_id)
+  end)
+
+  it("resolves a change line from its item", function()
+    local item = { change_id = "abcdef12", bookmarks = { "main", "feat" } }
+    local ctx = Ui.resolve_context { kind = "change", item = item, oid = "abcdef12" }
+    assert.are.equal("change", ctx.kind)
+    assert.are.equal("abcdef12", ctx.change_id)
+    assert.are.same({ "main", "feat" }, ctx.bookmarks)
+  end)
+
+  it("resolves a change line with node-level bookmarks (head/parent header)", function()
+    local ctx = Ui.resolve_context { kind = "change", oid = "abcdef12", bookmarks = { "main" } }
+    assert.are.equal("abcdef12", ctx.change_id)
+    assert.are.same({ "main" }, ctx.bookmarks)
+  end)
+
+  it("prefers the item change_id over the node oid", function()
+    -- Divergent variant rows set oid to a commit_id; the item carries the change_id
+    local item = { change_id = "abcdef12", commit_id = "0123beef" }
+    local ctx = Ui.resolve_context { kind = "change", item = item, oid = "0123beef" }
+    assert.are.equal("abcdef12", ctx.change_id)
+  end)
+
+  it("resolves the commit_id from the item or the node options", function()
+    local item = { change_id = "abcdef12", commit_id = "0123beef" }
+    assert.are.equal("0123beef", Ui.resolve_context({ kind = "change", item = item }).commit_id)
+    -- Head/parent header lines carry no item; commit_id comes from the node
+    assert.are.equal("0123beef", Ui.resolve_context({ kind = "change", commit_id = "0123beef" }).commit_id)
+  end)
+
+  it("does not treat the oid as a change_id for non-change kinds", function()
+    local ctx = Ui.resolve_context { kind = "file", item = { name = "foo.lua" }, oid = "0123beef" }
+    assert.are.equal("file", ctx.kind)
+    assert.is_nil(ctx.change_id)
+    assert.are.same({}, ctx.bookmarks)
+  end)
+end)


### PR DESCRIPTION
## Summary

Adds a forge integration (GitHub today, designed for GitLab etc. to slot in later) that matches local bookmarks to open PRs and surfaces them in the status buffer:

- **Inline annotation**: bookmarks with a matching open PR show their PR number (e.g. `my-feature #22`) on change lines, head/parent lines, and in the Bookmarks section, highlighted with the new `NeojjForgePR` group.
- **`o` precedence**: project header → repo URL, line annotated with a PR → PR URL, otherwise → commit URL (unchanged).
- **Gating, cheapest first**: `forge.pr_integration` config flag (default on) → `vim.fn.executable("gh")` → remote host matches a provider. Only then is one async `gh pr list` spawned per status refresh; failures (not logged in, network) degrade silently and are not retried within the session.
- **Fork safety**: cross-repository PRs are excluded from matching — their head ref names live in the fork's namespace and would falsely match local bookmarks (e.g. a fork PR from the fork's `main`).
- **GitHub Enterprise**: extra hosts via `forge = { hosts = { github = { "git.corp.com" } } }`.

## Architecture

- `lib/forge/init.lua` — provider-agnostic core: registry, host resolution, gating, async fetch, per-root fail-once cache, branch→PR index.
- `lib/forge/github.lua` — the GitHub provider (~50 lines): identity, `gh pr list` command, JSON → normalized `ForgePR` parsing. A future GitLab provider is one new file plus a registry entry.
- `lib/jj/remote.lua` — remote URL parsing/caching, extracted from the previously-inlined logic in `n_open_in_browser` (which also de-duplicated the three copies of bookmark-part rendering in the status UI).

## Testing

- New specs for `remote.parse`, `github.parse_prs`, and the forge core (host resolution, indexing, cache seams); config validation specs for the new `forge` option.
- Full suite passes (23 spec files, 0 failures); selene, stylua, typos, and llscheck clean.
- Headless end-to-end smoke test against this repo: remote resolved, `gh` fetch completed, and fork PR #22 correctly produced no false bookmark match.