### PR TITLE
feat: make project header configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ neojj.setup {
   jj_binary = "auto",
   -- Hides the hints at the top of the status buffer
   disable_hint = false,
+  -- Shows the project name at the top of the status buffer
+  show_project_header = true,
   -- Disables changing the buffer highlights based on where the cursor is.
   disable_context_highlighting = false,
   -- Disables signs for sections/items/hunks

--- a/doc/neojj.txt
+++ b/doc/neojj.txt
@@ -96,6 +96,9 @@ the available options with their defaults: >lua
       -- Hides the hints at the top of the status buffer
       disable_hint = false,
 
+      -- Shows the project name at the top of the status buffer
+      show_project_header = true,
+
       -- Disables changing the buffer highlights based on cursor position
       disable_context_highlighting = false,
 

--- a/lua/neojj/buffers/status/ui.lua
+++ b/lua/neojj/buffers/status/ui.lua
@@ -456,6 +456,8 @@ function M.Status(state, config)
   -- stylua: ignore start
   local show_hint = not config.disable_hint
 
+  local show_project_header = config.show_project_header
+
   local show_files = state.files and #state.files.items > 0
 
   local show_conflicts = state.conflicts and #state.conflicts.items > 0
@@ -472,8 +474,8 @@ function M.Status(state, config)
       items = {
         show_hint and HINT { config = config },
         show_hint and EmptyLine(),
-        ProjectHeader { root = state.worktree_root },
-        EmptyLine(),
+        show_project_header and ProjectHeader { root = state.worktree_root },
+        show_project_header and EmptyLine(),
         col.tag("Section")({
           JJHead {
             name = "Change",

--- a/lua/neojj/config.lua
+++ b/lua/neojj/config.lua
@@ -287,6 +287,7 @@ end
 ---@field commit_date_format? string Commit date format
 ---@field log_date_format? string Log date format
 ---@field disable_hint? boolean Remove the top hint in the Status buffer
+---@field show_project_header? boolean Show the project name at the top of the Status buffer
 ---@field disable_context_highlighting? boolean Disable context highlights based on cursor position
 ---@field disable_signs? boolean Special signs to draw for sections etc. in Neojj
 ---@field prompt_amend_commit? boolean Request confirmation when amending already published commits
@@ -333,6 +334,7 @@ function M.get_default_values()
     jj_binary = "auto",
     use_default_keymaps = true,
     disable_hint = false,
+    show_project_header = true,
     disable_context_highlighting = false,
     disable_signs = false,
     prompt_amend_commit = true,
@@ -991,6 +993,7 @@ function M.validate_config()
 
   if validate_type(config, "base config", "table") then
     validate_type(config.disable_hint, "disable_hint", "boolean")
+    validate_type(config.show_project_header, "show_project_header", "boolean")
     validate_type(config.disable_context_highlighting, "disable_context_highlighting", "boolean")
     validate_type(config.disable_signs, "disable_signs", "boolean")
     validate_type(config.telescope_sorter, "telescope_sorter", "function")

--- a/tests/specs/neojj/buffers/status/ui_spec.lua
+++ b/tests/specs/neojj/buffers/status/ui_spec.lua
@@ -12,6 +12,63 @@ local function find_file_items(component, result)
   return result
 end
 
+local function find_component_by_kind(component, kind)
+  if component.options and component.options.kind == kind then
+    return component
+  end
+  for _, child in ipairs(component.children or {}) do
+    local match = find_component_by_kind(child, kind)
+    if match then
+      return match
+    end
+  end
+end
+
+local function minimal_state()
+  return {
+    worktree_root = "/workspace/project-name",
+    head = {
+      change_id = "abcdefgh",
+      commit_id = "12345678",
+      description = "working copy",
+      bookmarks = {},
+      empty = false,
+      conflict = false,
+    },
+    parent = {
+      change_id = "ijklmnop",
+      commit_id = "87654321",
+      description = "parent",
+      bookmarks = {},
+    },
+    files = { items = {} },
+    conflicts = { items = {} },
+    recent = { items = {} },
+    bookmarks = { items = {} },
+  }
+end
+
+describe("status project header", function()
+  it("shows the project name by default", function()
+    local layout = status_ui.Status(minimal_state(), config.get_default_values())
+    local project = find_component_by_kind(layout[1], "project")
+
+    assert.is_not_nil(project)
+    assert.are.equal("project-name", project.children[1].value)
+  end)
+
+  it("hides the project name when disabled", function()
+    local values = config.get_default_values()
+    values.disable_hint = true
+    values.show_project_header = false
+
+    local layout = status_ui.Status(minimal_state(), values)
+
+    assert.is_nil(find_component_by_kind(layout[1], "project"))
+    assert.are.equal(2, #layout[1].children)
+  end)
+end)
+
 describe("status file highlights", function()
   it("colors mode labels by file state without coloring filenames", function()
     local values = config.get_default_values()

--- a/tests/specs/neojj/config_spec.lua
+++ b/tests/specs/neojj/config_spec.lua
@@ -17,6 +17,11 @@ describe("NeoJJ config", function()
         assert.True(vim.tbl_count(require("neojj.config").validate_config()) ~= 0)
       end)
 
+      it("should return invalid when show_project_header isn't a boolean", function()
+        config.values.show_project_header = "not a boolean"
+        assert.True(vim.tbl_count(require("neojj.config").validate_config()) ~= 0)
+      end)
+
       it("should return invalid when disable_context_highlighting isn't a boolean", function()
         config.values.disable_context_highlighting = "not a boolean"
         assert.True(vim.tbl_count(require("neojj.config").validate_config()) ~= 0)


### PR DESCRIPTION
## Summary

- add a `show_project_header` option that defaults to `true`
- hide the project header and its spacer when the option is disabled
- document and validate the option, with status UI coverage

## Testing

- `make test`
- pre-commit checks: Selene, StyLua, typos, and llscheck
- pre-push checks: Selene, StyLua, typos, llscheck, and the full test suite
