### PR TITLE
feat: prompt to initialize jj repositories

### DIFF
--- a/lua/neojj.lua
+++ b/lua/neojj.lua
@@ -140,10 +140,10 @@ function M.open(opts)
   opts = construct_opts(opts)
 
   if not opts._workspace_root then
-    local failed_path = vim.fn.expand(opts.cwd or ".")
-    M.notification.error(("The directory `%s` is not a jj workspace"):format(failed_path))
-
-    return
+    opts._workspace_root = require("neojj.lib.jj.workspace").prompt_init(opts.cwd)
+    if not opts._workspace_root then
+      return
+    end
   end
 
   if opts[1] ~= nil then

--- a/lua/neojj/lib/jj/cli.lua
+++ b/lua/neojj/lib/jj/cli.lua
@@ -35,6 +35,7 @@ local runner = require("neojj.runner")
 ---@field simplify_parents NeojjCliBuilder
 ---@field list NeojjCliBuilder
 ---@field all_remotes NeojjCliBuilder
+---@field colocate NeojjCliBuilder
 ---@field allow_backwards NeojjCliBuilder
 ---@field overwrite_existing NeojjCliBuilder
 ---@field all NeojjCliBuilder
@@ -91,6 +92,7 @@ local runner = require("neojj.runner")
 ---@field bookmark_rename NeojjCliBuilder
 ---@field bookmark_set NeojjCliBuilder
 ---@field bookmark_advance NeojjCliBuilder
+---@field git_init NeojjCliBuilder
 ---@field git_push NeojjCliBuilder
 ---@field git_fetch NeojjCliBuilder
 ---@field git_remote_add NeojjCliBuilder
@@ -577,6 +579,13 @@ define_command("bookmark advance", {
   },
 })
 
+-- jj git init
+define_command("git init", {
+  flags = {
+    colocate = "--colocate",
+  },
+})
+
 -- jj git push
 define_command("git push", {
   flags = {
@@ -789,7 +798,7 @@ setmetatable(M, {
 -- Utility functions
 -- ============================================================
 
----@type table<string, string|false>
+---@type table<string, string>
 local workspace_root_cache = {}
 
 ---Find workspace root by walking up looking for .jj directory (no subprocess needed)
@@ -817,9 +826,8 @@ function M.find_workspace_root(dir)
   dir = dir or vim.fn.getcwd()
   local key = vim.fn.fnamemodify(dir, ":p")
 
-  if workspace_root_cache[key] ~= nil then
-    local cached = workspace_root_cache[key]
-    return cached ~= false and cached or nil
+  if workspace_root_cache[key] then
+    return workspace_root_cache[key]
   end
 
   local root = find_jj_root(dir)
@@ -833,7 +841,8 @@ function M.find_workspace_root(dir)
     return root
   end
 
-  workspace_root_cache[key] = false
+  -- Do not cache misses: a workspace can be initialized while Neovim is
+  -- running, and the next :Neojj invocation must discover it.
   return nil
 end
 

--- a/lua/neojj/lib/jj/workspace.lua
+++ b/lua/neojj/lib/jj/workspace.lua
@@ -1,0 +1,40 @@
+local M = {}
+
+local cli = require("neojj.lib.jj.cli")
+local input = require("neojj.lib.input")
+local notification = require("neojj.lib.notification")
+local picker_cache = require("neojj.lib.picker_cache")
+
+local function notify_not_workspace(path)
+  notification.error(("The directory `%s` is not a jj workspace"):format(path))
+end
+
+---Prompt to initialize a jj workspace and return its root on success.
+---@param dir string
+---@return string|nil root
+function M.prompt_init(dir)
+  local path = vim.fn.fnamemodify(dir, ":p"):gsub("/$", "")
+
+  if not input.get_permission(("Initialize jj repository in `%s`?"):format(path)) then
+    notify_not_workspace(path)
+    return nil
+  end
+
+  local result = cli.git_init.colocate.args(path).call { await = true }
+  if not result or result.code ~= 0 then
+    local message = picker_cache.error_msg(result)
+    notification.error(("Failed to initialize jj repository in `%s`: %s"):format(path, message))
+    return nil
+  end
+
+  cli.clear_cache()
+  local root = cli.find_workspace_root(path)
+  if not root then
+    notification.error(("jj initialized successfully, but `%s` is not a jj workspace"):format(path))
+    return nil
+  end
+
+  return root
+end
+
+return M

--- a/tests/specs/neojj/lib/jj/cli_spec.lua
+++ b/tests/specs/neojj/lib/jj/cli_spec.lua
@@ -147,6 +147,15 @@ describe("jj cli builder", function()
     end)
   end)
 
+  describe("git init command", function()
+    it("builds a colocated init command", function()
+      local str = tostring(cli.git_init.colocate.args("/tmp/project"))
+      assert.truthy(str:find("git init"))
+      assert.truthy(str:find("%-%-colocate"))
+      assert.truthy(str:find("/tmp/project"))
+    end)
+  end)
+
   describe("git push command", function()
     it("includes --bookmark option", function()
       local str = tostring(cli.git_push.bookmark("main"))
@@ -241,6 +250,29 @@ describe("jj cli builder", function()
       local str = tostring(cli.config_unset.repo.args("key"))
       assert.truthy(str:find("%-%-repo"))
       assert.truthy(str:find("config unset"))
+    end)
+  end)
+
+  describe("workspace root discovery", function()
+    local directory
+
+    before_each(function()
+      directory = vim.fn.tempname()
+      vim.fn.mkdir(directory, "p")
+      cli.clear_cache()
+    end)
+
+    after_each(function()
+      vim.fn.delete(directory, "rf")
+      cli.clear_cache()
+    end)
+
+    it("discovers a workspace initialized after an earlier miss", function()
+      assert.is_nil(cli.find_workspace_root(directory))
+
+      vim.fn.mkdir(directory .. "/.jj", "p")
+
+      assert.are.equal(directory, cli.find_workspace_root(directory))
     end)
   end)
 end)

--- a/tests/specs/neojj/lib/jj/workspace_spec.lua
+++ b/tests/specs/neojj/lib/jj/workspace_spec.lua
@@ -1,0 +1,170 @@
+local MODULE = "neojj.lib.jj.workspace"
+local harness = require("tests.util.jj_harness")
+
+---@param stubs table<string, any>
+---@param fn fun(workspace: table)
+local function with_workspace_module(stubs, fn)
+  local saved = {}
+  for name, mod in pairs(stubs) do
+    saved[name] = package.loaded[name]
+    package.loaded[name] = mod
+  end
+
+  local saved_subject = package.loaded[MODULE]
+  package.loaded[MODULE] = nil
+
+  local ok, err = pcall(function()
+    fn(require(MODULE))
+  end)
+
+  package.loaded[MODULE] = saved_subject
+  for name, _ in pairs(stubs) do
+    package.loaded[name] = saved[name]
+  end
+
+  assert.is_true(ok, err)
+end
+
+local function cli_stub(state, result)
+  return {
+    git_init = {
+      colocate = {
+        args = function(path)
+          state.init_path = path
+          return {
+            call = function(opts)
+              state.call_opts = opts
+              return result
+            end,
+          }
+        end,
+      },
+    },
+    clear_cache = function()
+      state.cache_cleared = true
+    end,
+    find_workspace_root = function(path)
+      state.root_path = path
+      return state.root
+    end,
+  }
+end
+
+describe("jj workspace initialization", function()
+  local directory
+
+  before_each(function()
+    directory = vim.fn.tempname()
+    vim.fn.mkdir(directory, "p")
+  end)
+
+  after_each(function()
+    vim.fn.delete(directory, "rf")
+  end)
+
+  it("keeps the not-a-workspace error when initialization is declined", function()
+    local state = {}
+    local errors = {}
+
+    with_workspace_module({
+      ["neojj.lib.jj.cli"] = cli_stub(state, { code = 0 }),
+      ["neojj.lib.input"] = {
+        get_permission = function(message)
+          state.prompt = message
+          return false
+        end,
+      },
+      ["neojj.lib.notification"] = {
+        error = function(message)
+          table.insert(errors, message)
+        end,
+      },
+      ["neojj.lib.picker_cache"] = { error_msg = function() end },
+    }, function(workspace)
+      assert.is_nil(workspace.prompt_init(directory))
+    end)
+
+    assert.truthy(state.prompt:find("Initialize jj repository", 1, true))
+    assert.is_nil(state.init_path)
+    assert.truthy(errors[1]:find("is not a jj workspace", 1, true))
+  end)
+
+  it("initializes a colocated repository and returns its root", function()
+    local state = { root = directory }
+
+    with_workspace_module({
+      ["neojj.lib.jj.cli"] = cli_stub(state, { code = 0 }),
+      ["neojj.lib.input"] = {
+        get_permission = function()
+          return true
+        end,
+      },
+      ["neojj.lib.notification"] = { error = function() end },
+      ["neojj.lib.picker_cache"] = {
+        error_msg = function()
+          return ""
+        end,
+      },
+    }, function(workspace)
+      assert.are.equal(directory, workspace.prompt_init(directory))
+    end)
+
+    assert.are.equal(directory, state.init_path)
+    assert.is_true(state.call_opts.await)
+    assert.is_true(state.cache_cleared)
+    assert.are.equal(directory, state.root_path)
+  end)
+
+  it("initializes a real jj repository", function()
+    if not harness.jj_available() then
+      pending("jj binary not available; skipping integration test")
+      return
+    end
+
+    local input = require("neojj.lib.input")
+    local original_get_permission = input.get_permission
+    input.get_permission = function()
+      return true
+    end
+
+    package.loaded[MODULE] = nil
+    local ok, root = pcall(function()
+      return require(MODULE).prompt_init(directory)
+    end)
+    input.get_permission = original_get_permission
+    package.loaded[MODULE] = nil
+
+    assert.is_true(ok, root)
+    assert.are.equal(directory, root)
+    assert.are.equal(1, vim.fn.isdirectory(directory .. "/.jj"))
+  end)
+
+  it("reports jj init failures without opening a workspace", function()
+    local state = {}
+    local errors = {}
+
+    with_workspace_module({
+      ["neojj.lib.jj.cli"] = cli_stub(state, { code = 1, stderr = { "init failed" } }),
+      ["neojj.lib.input"] = {
+        get_permission = function()
+          return true
+        end,
+      },
+      ["neojj.lib.notification"] = {
+        error = function(message)
+          table.insert(errors, message)
+        end,
+      },
+      ["neojj.lib.picker_cache"] = {
+        error_msg = function()
+          return "init failed"
+        end,
+      },
+    }, function(workspace)
+      assert.is_nil(workspace.prompt_init(directory))
+    end)
+
+    assert.is_nil(state.cache_cleared)
+    assert.truthy(errors[1]:find("init failed", 1, true))
+  end)
+end)


### PR DESCRIPTION
## Summary

- prompt to initialize a jj repository when `:Neojj` is opened outside a workspace
- run `jj git init --colocate`, clear workspace detection state, and continue opening the status UI after success
- stop caching failed workspace lookups so repositories initialized while Neovim is running are detected
- preserve the existing error when initialization is declined and report initialization failures

## Testing

- `make test`
- `stylua --check lua/neojj.lua lua/neojj/lib/jj/cli.lua lua/neojj/lib/jj/workspace.lua tests/specs/neojj/lib/jj/cli_spec.lua tests/specs/neojj/lib/jj/workspace_spec.lua`
- manually verified the initialization prompt and successful status UI opening from the main checkout

Closes #31
Closes #32
