### PR TITLE
fix: show binary changes and preserve status tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ neojj.setup {
   -- Which diff viewer to use. nil = auto-detect (tries diffview first, then codediff).
   -- Can be "diffview" or "codediff".
   diff_viewer = nil,
+  -- Place new CodeDiff tabs before or after the current tab.
+  codediff_tab_position = "after",
   -- Forge (GitHub, ...) integration. When enabled and the forge CLI (`gh`) is
   -- installed, bookmarks with a matching open PR are annotated with the PR
   -- number, and "o" on such a line opens the PR instead of the commit.

--- a/doc/neojj.txt
+++ b/doc/neojj.txt
@@ -228,6 +228,9 @@ the available options with their defaults: >lua
       -- Which diff viewer to use (nil = auto-detect)
       diff_viewer = nil,
 
+      -- Place new CodeDiff tabs before or after the current tab
+      codediff_tab_position = "after",
+
       -- Forge (GitHub, ...) integration: annotate bookmarks with open PRs
       -- and let "o" open the PR in the browser. Requires the forge CLI
       -- (`gh`) to be installed; disabled silently otherwise.

--- a/lua/neojj/buffers/commit_view/parsing.lua
+++ b/lua/neojj/buffers/commit_view/parsing.lua
@@ -26,7 +26,7 @@ function M.parse_commit_overview(raw)
   local start_idx = nil
 
   for i = end_idx, 1, -1 do
-    if raw[i]:match("%s*|%s+%d") or raw[i]:match("%s*|%s+Bin ") then
+    if raw[i]:match("%s*|%s+%d") or raw[i]:match("%s*|%s+Bin ") or raw[i]:match("%s*|%s+%(binary%)") then
       start_idx = i
     else
       if start_idx then
@@ -50,6 +50,11 @@ function M.parse_commit_overview(raw)
       if vim.tbl_isempty(file) then
         -- matches: .../db/b8571c4f873daff059c04443077b43a703338a      | Bin 0 -> 192 bytes
         file.path, file.changes = raw[i]:match("^(.-)%s+|%s+(Bin .*)$")
+      end
+
+      if vim.tbl_isempty(file) then
+        -- matches modern jj output: image.png | (binary) +10 bytes
+        file.path, file.changes = raw[i]:match("^(.-)%s+|%s+(%(binary%).*)$")
       end
 
       if not vim.tbl_isempty(file) then

--- a/lua/neojj/config.lua
+++ b/lua/neojj/config.lua
@@ -316,6 +316,7 @@ end
 ---@field integrations? { diffview: boolean, codediff: boolean, telescope: boolean, fzf_lua: boolean, mini_pick: boolean, snacks: boolean } Which integrations to enable
 ---@field forge? NeojjForgeConfig Forge (GitHub, ...) integration options
 ---@field diff_viewer? "diffview"|"codediff"|nil Which diff viewer to use (nil = auto-detect)
+---@field codediff_tab_position? "after"|"before" Position new CodeDiff tabs relative to the current tab
 ---@field sections? NeojjConfigSections
 ---@field ignored_settings? string[] Settings to never persist, format: "Filetype--cli-value", i.e. "NeojjCommitPopup--author"
 ---@field mappings? NeojjConfigMappings
@@ -445,6 +446,7 @@ function M.get_default_values()
       hosts = {},
     },
     diff_viewer = nil,
+    codediff_tab_position = "after",
     sections = {
       sequencer = {
         folded = false,
@@ -705,6 +707,20 @@ function M.validate_config()
           "Expected diff_viewer to be one of %s or nil, got '%s'",
           table.concat(valid_viewers, ", "),
           tostring(config.diff_viewer)
+        )
+      )
+    end
+  end
+
+  local function validate_codediff_tab_position()
+    local valid_positions = { "after", "before" }
+    if not vim.tbl_contains(valid_positions, config.codediff_tab_position) then
+      err(
+        "codediff_tab_position",
+        string.format(
+          "Expected codediff_tab_position to be one of %s, got '%s'",
+          table.concat(valid_positions, ", "),
+          tostring(config.codediff_tab_position)
         )
       )
     end
@@ -1014,6 +1030,7 @@ function M.validate_config()
     validate_type(config.auto_show_console, "auto_show_console", "boolean")
     validate_type(config.auto_show_console_on, "auto_show_console_on", "string")
     validate_type(config.auto_close_console, "auto_close_console", "boolean")
+    validate_codediff_tab_position()
     validate_type(config.workspace_open_command, "workspace_open_command", { "string", "function", "nil" })
     validate_type(
       config.workspace_initialize_command,

--- a/lua/neojj/integrations/codediff.lua
+++ b/lua/neojj/integrations/codediff.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local jj = require("neojj.lib.jj")
 local jj_backend = require("neojj.integrations.jj_backend")
+local config = require("neojj.config")
 
 -- Non-colocated jj workspaces have no `.git`, so codediff's git subprocess
 -- calls (which use cwd=<workspace>) fail. Wrap each codediff git function so
@@ -130,6 +131,19 @@ local function make_explorer_data(status_result, focus_file)
   return explorer_data
 end
 
+---@param view table
+---@param session_config table
+---@param filetype string
+local function create_view(view, session_config, filetype)
+  local current_tab = vim.api.nvim_get_current_tabpage()
+  view.create(session_config, filetype)
+  if
+    config.values.codediff_tab_position == "before" and vim.api.nvim_get_current_tabpage() ~= current_tab
+  then
+    vim.cmd("tabmove -1")
+  end
+end
+
 local function open_explorer(view, git_root, status_result, original_revision, modified_revision, focus_file)
   ---@type table
   local session_config = {
@@ -142,7 +156,7 @@ local function open_explorer(view, git_root, status_result, original_revision, m
     explorer_data = make_explorer_data(status_result, focus_file),
   }
 
-  view.create(session_config, "")
+  create_view(view, session_config, "")
 end
 
 local function open_status_explorer(codediff_git, view, git_root, focus_file)
@@ -422,7 +436,7 @@ function M.open(section_name, item_name, opts)
         modified_revision = modified_revision,
         conflict = true,
       }
-      view.create(session_config, filetype)
+      create_view(view, session_config, filetype)
     else
       open_status_explorer(codediff_git, view, git_root)
     end

--- a/tests/specs/neojj/buffers/commit_view/parsing_spec.lua
+++ b/tests/specs/neojj/buffers/commit_view/parsing_spec.lua
@@ -1,0 +1,38 @@
+local parser = require("neojj.buffers.commit_view.parsing")
+
+describe("commit overview parsing", function()
+  it("includes modern jj binary stat lines", function()
+    local overview = parser.parse_commit_overview {
+      "image.png | (binary) +10 bytes",
+      "notes.txt | 2 +-",
+      "2 files changed, 1 insertion(+), 1 deletion(-)",
+    }
+
+    assert.are.same({
+      {
+        path = "image.png",
+        changes = "(binary) +10 bytes",
+      },
+      {
+        path = "notes.txt",
+        changes = "2",
+        insertions = "+",
+        deletions = "-",
+      },
+    }, overview.files)
+  end)
+
+  it("continues to include Git-style binary stat lines", function()
+    local overview = parser.parse_commit_overview {
+      "image.png | Bin 10 -> 20 bytes",
+      "1 file changed, 0 insertions(+), 0 deletions(-)",
+    }
+
+    assert.are.same({
+      {
+        path = "image.png",
+        changes = "Bin 10 -> 20 bytes",
+      },
+    }, overview.files)
+  end)
+end)

--- a/tests/specs/neojj/config_spec.lua
+++ b/tests/specs/neojj/config_spec.lua
@@ -32,6 +32,11 @@ describe("NeoJJ config", function()
         assert.True(vim.tbl_count(require("neojj.config").validate_config()) ~= 0)
       end)
 
+      it("should return invalid when codediff_tab_position is unknown", function()
+        config.values.codediff_tab_position = "unknown"
+        assert.True(vim.tbl_count(require("neojj.config").validate_config()) ~= 0)
+      end)
+
       it("should return invalid when telescope_sorter isn't a function", function()
         config.values.telescope_sorter = "not a function"
         assert.True(vim.tbl_count(require("neojj.config").validate_config()) ~= 0)
@@ -605,6 +610,11 @@ describe("NeoJJ config", function()
 
       it("should return valid when diff_viewer is 'codediff'", function()
         config.values.diff_viewer = "codediff"
+        assert.True(vim.tbl_count(require("neojj.config").validate_config()) == 0)
+      end)
+
+      it("should return valid when codediff_tab_position is 'before'", function()
+        config.values.codediff_tab_position = "before"
         assert.True(vim.tbl_count(require("neojj.config").validate_config()) == 0)
       end)
 

--- a/tests/specs/neojj/integration/codediff_integration_spec.lua
+++ b/tests/specs/neojj/integration/codediff_integration_spec.lua
@@ -1,12 +1,13 @@
--- Tests the codediff integration's non-colocated jj workaround. The codediff
--- plugin is not installed in the test environment, so we verify two things:
+-- Tests the codediff integration without requiring codediff.nvim. We verify:
 --   1. The env-wrapping proxy sets `GIT_DIR`/`GIT_WORK_TREE` during the call
 --      and restores them afterwards, preserving prior values.
 --   2. Running real `git` with those env vars against jj's backing store
 --      actually succeeds in a non-colocated workspace.
+--   3. Configured CodeDiff tab placement preserves the status tab.
 
 local harness = require("tests.util.jj_harness")
 local jj_backend = require("neojj.integrations.jj_backend")
+local config = require("neojj.config")
 
 local function skip_if_no_jj()
   if not harness.jj_available() then
@@ -125,6 +126,97 @@ describe("codediff integration — env wrapper", function()
     assert.is_false(ok)
     assert.are.equal("/before", vim.env.GIT_DIR)
     vim.env.GIT_DIR = nil
+  end)
+end)
+
+describe("codediff integration — tab position", function()
+  local original_tab
+  local status_tab
+  local created_tab
+  local loaded_jj
+  local loaded_codediff
+  local loaded_codediff_git
+  local loaded_codediff_view
+
+  local function tab_index(tabpage)
+    for index, tab in ipairs(vim.api.nvim_list_tabpages()) do
+      if tab == tabpage then
+        return index
+      end
+    end
+  end
+
+  before_each(function()
+    created_tab = nil
+    original_tab = vim.api.nvim_get_current_tabpage()
+    vim.cmd("tabnew")
+    status_tab = vim.api.nvim_get_current_tabpage()
+
+    loaded_jj = package.loaded["neojj.lib.jj"]
+    loaded_codediff = package.loaded["neojj.integrations.codediff"]
+    loaded_codediff_git = package.loaded["codediff.core.git"]
+    loaded_codediff_view = package.loaded["codediff.ui.view"]
+
+    package.loaded["neojj.lib.jj"] = {
+      repo = { worktree_root = vim.fn.getcwd() },
+    }
+    package.loaded["codediff.core.git"] = {
+      get_status = function(_, callback)
+        callback(nil, {})
+      end,
+      get_diff_revisions = function() end,
+      resolve_revision = function() end,
+      get_relative_path = function(path)
+        return path
+      end,
+    }
+    package.loaded["codediff.ui.view"] = {
+      create = function()
+        vim.cmd("tabnew")
+        created_tab = vim.api.nvim_get_current_tabpage()
+      end,
+    }
+    package.loaded["neojj.integrations.codediff"] = nil
+  end)
+
+  after_each(function()
+    for _, tab in ipairs { created_tab, status_tab } do
+      if tab and vim.api.nvim_tabpage_is_valid(tab) then
+        vim.api.nvim_set_current_tabpage(tab)
+        vim.cmd("tabclose!")
+      end
+    end
+    if vim.api.nvim_tabpage_is_valid(original_tab) then
+      vim.api.nvim_set_current_tabpage(original_tab)
+    end
+
+    package.loaded["neojj.lib.jj"] = loaded_jj
+    package.loaded["neojj.integrations.codediff"] = loaded_codediff
+    package.loaded["codediff.core.git"] = loaded_codediff_git
+    package.loaded["codediff.ui.view"] = loaded_codediff_view
+    config.values.codediff_tab_position = "after"
+  end)
+
+  local function open_codediff(position)
+    config.values.codediff_tab_position = position
+    require("neojj.integrations.codediff").open("worktree")
+    assert.is_true(vim.wait(500, function()
+      return created_tab ~= nil
+    end))
+  end
+
+  it("leaves the new tab after the status tab by default", function()
+    open_codediff("after")
+
+    assert.are.equal(2, tab_index(status_tab))
+    assert.are.equal(3, tab_index(created_tab))
+  end)
+
+  it("can place the new tab before the status tab", function()
+    open_codediff("before")
+
+    assert.are.equal(2, tab_index(created_tab))
+    assert.are.equal(3, tab_index(status_tab))
   end)
 end)
 


### PR DESCRIPTION
## Summary

Commit views omitted binary files because modern `jj show --stat` labels them as `(binary)` while NeoJJ only recognized Git-style `Bin` lines. CodeDiff also always opened after the NeoJJ tab, so CodeDiff's open-in-previous-tab action could replace the status buffer.

This recognizes both binary-stat formats and adds `codediff_tab_position = "before"` as an opt-in that places the new CodeDiff tab before NeoJJ while preserving the existing `"after"` default.

Closes #42
Closes #43

## Test plan

- [x] `make test`
- [x] `stylua --check .`
- [x] `mise x cargo:selene@0.31.0 -- selene --config selene/config.toml lua`
- [x] `mise x cargo:typos-cli@1.48.0 -- typos`
- [x] `mise x asdf:mise-plugins/mise-lua@5.1.5 -- llscheck lua/`

Generated with OpenCode.